### PR TITLE
feat: Add Biodata Form to Profile Page with Backend Integration

### DIFF
--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -8,30 +8,17 @@ import { useNavigate } from 'react-router-dom';
 import { sendTrackingLogEvent } from '@edx/frontend-platform/analytics';
 import { ensureConfig } from '@edx/frontend-platform';
 import { AppContext } from '@edx/frontend-platform/react';
-import { FormattedMessage, useIntl } from '@edx/frontend-platform/i18n';
-import {
-  Alert, Hyperlink, OverlayTrigger, Tooltip,
-} from '@openedx/paragon';
-import { InfoOutline } from '@openedx/paragon/icons';
+import { useIntl } from '@edx/frontend-platform/i18n';
+import { Alert, Hyperlink } from '@openedx/paragon';
 import classNames from 'classnames';
 
 import {
   fetchProfile,
-  saveProfile,
   saveProfilePhoto,
   deleteProfilePhoto,
-  openForm,
-  closeForm,
-  updateDraft,
 } from './data/actions';
 
 import ProfileAvatar from './forms/ProfileAvatar';
-import Name from './forms/Name';
-import Country from './forms/Country';
-import PreferredLanguage from './forms/PreferredLanguage';
-import Education from './forms/Education';
-import SocialLinks from './forms/SocialLinks';
-import Bio from './forms/Bio';
 import DateJoined from './DateJoined';
 import UserCertificateSummary from './UserCertificateSummary';
 import PageLoading from './PageLoading';
@@ -42,7 +29,7 @@ import messages from './ProfilePage.messages';
 import withParams from '../utils/hoc';
 import { useIsOnMobileScreen, useIsOnTabletScreen } from './data/hooks';
 
-import AdditionalProfileFieldsSlot from '../plugin-slots/AdditionalProfileFieldsSlot';
+import BiodataProfileSections from './biodata/BiodataProfileSections';
 
 ensureConfig(['CREDENTIALS_BASE_URL', 'LMS_BASE_URL', 'ACCOUNT_SETTINGS_URL'], 'ProfilePage');
 
@@ -53,23 +40,10 @@ const ProfilePage = ({ params }) => {
   const {
     dateJoined,
     courseCertificates,
-    name,
-    visibilityName,
     profileImage,
     savePhotoState,
     isLoadingProfile,
     photoUploadError,
-    country,
-    visibilityCountry,
-    levelOfEducation,
-    visibilityLevelOfEducation,
-    socialLinks,
-    draftSocialLinksByPlatform,
-    visibilitySocialLinks,
-    languageProficiencies,
-    visibilityLanguageProficiencies,
-    bio,
-    visibilityBio,
     saveState,
     username,
   } = useSelector(profilePageSelector);
@@ -107,22 +81,6 @@ const ProfilePage = ({ params }) => {
     dispatch(deleteProfilePhoto(authenticatedUserName));
   }, [dispatch, authenticatedUserName]);
 
-  const handleClose = useCallback((formId) => {
-    dispatch(closeForm(formId));
-  }, [dispatch]);
-
-  const handleOpen = useCallback((formId) => {
-    dispatch(openForm(formId));
-  }, [dispatch]);
-
-  const handleSubmit = useCallback((formId) => {
-    dispatch(saveProfile(formId, authenticatedUserName));
-  }, [dispatch, authenticatedUserName]);
-
-  const handleChange = useCallback((fieldName, value) => {
-    dispatch(updateDraft(fieldName, value));
-  }, [dispatch]);
-
   const isAuthenticatedUserProfile = () => params.username === authenticatedUserName;
 
   const isBlockVisible = (blockInfo) => isAuthenticatedUserProfile()
@@ -159,13 +117,6 @@ const ProfilePage = ({ params }) => {
       </div>
     )
   );
-
-  const commonFormProps = {
-    openHandler: handleOpen,
-    closeHandler: handleClose,
-    submitHandler: handleSubmit,
-    changeHandler: handleChange,
-  };
 
   return (
     <div className="profile-page">
@@ -224,11 +175,6 @@ const ProfilePage = ({ params }) => {
                     <p className="row m-0 font-weight-bold text-truncate text-primary-500 h3">
                       {params.username}
                     </p>
-                    {isBlockVisible(name) && (
-                    <p className="row pt-2 text-gray-800 font-weight-normal m-0 p">
-                      {name}
-                    </p>
-                    )}
                     <div className={classNames(
                       'row pt-2 m-0',
                       isMobileView
@@ -261,123 +207,7 @@ const ProfilePage = ({ params }) => {
             ])}
           >
             <div className="w-100 p-0">
-              <div className="col justify-content-start align-items-start p-0">
-                <div className="col align-self-stretch height-42px justify-content-start align-items-start p-0">
-                  <p className="font-weight-bold text-primary-500 m-0 h2">
-                    {isMobileView ? (
-                      <FormattedMessage
-                        id="profile.profile.information"
-                        defaultMessage="Profile"
-                        description="heading for the editable profile section in mobile view"
-                      />
-                    )
-                      : (
-                        <FormattedMessage
-                          id="profile.profile.information"
-                          defaultMessage="Profile information"
-                          description="heading for the editable profile section"
-                        />
-                      )}
-                  </p>
-                </div>
-              </div>
-              <div
-                className={classNames([
-                  'row m-0 px-0 w-100 d-inline-flex align-items-start justify-content-start',
-                  isMobileView ? 'pt-4' : 'pt-5.5',
-                ])}
-              >
-                <div
-                  className={classNames([
-                    'col p-0',
-                    isMobileView ? 'col-12' : 'col-6',
-                  ])}
-                >
-                  <div className="m-0">
-                    <div className="row m-0 pb-1.5 align-items-center">
-                      <p data-hj-suppress className="h5 font-weight-bold m-0">
-                        {intl.formatMessage(messages['profile.username'])}
-                      </p>
-                      <OverlayTrigger
-                        key="top"
-                        placement="top"
-                        overlay={(
-                          <Tooltip variant="light" id="tooltip-top">
-                            <p className="h5 font-weight-normal m-0 p-0">
-                              {intl.formatMessage(messages['profile.username.tooltip'])}
-                            </p>
-                          </Tooltip>
-                          )}
-                      >
-                        <InfoOutline className="m-0 info-icon" />
-                      </OverlayTrigger>
-                    </div>
-                    <h4 className="edit-section-header text-gray-700">
-                      {params.username}
-                    </h4>
-                  </div>
-                  {isBlockVisible(name) && (
-                  <Name
-                    name={name}
-                    accountSettingsUrl={context.config.ACCOUNT_SETTINGS_URL}
-                    visibilityName={visibilityName}
-                    formId="name"
-                    {...commonFormProps}
-                  />
-                  )}
-                  {isBlockVisible(country) && (
-                  <Country
-                    country={country}
-                    visibilityCountry={visibilityCountry}
-                    formId="country"
-                    {...commonFormProps}
-                  />
-                  )}
-                  {isBlockVisible((languageProficiencies || []).length) && (
-                  <PreferredLanguage
-                    languageProficiencies={languageProficiencies || []}
-                    visibilityLanguageProficiencies={visibilityLanguageProficiencies}
-                    formId="languageProficiencies"
-                    {...commonFormProps}
-                  />
-                  )}
-                  {isBlockVisible(levelOfEducation) && (
-                  <Education
-                    levelOfEducation={levelOfEducation}
-                    visibilityLevelOfEducation={visibilityLevelOfEducation}
-                    formId="levelOfEducation"
-                    {...commonFormProps}
-                  />
-                  )}
-
-                  <AdditionalProfileFieldsSlot />
-                </div>
-                <div
-                  className={classNames([
-                    'col m-0 pr-0',
-                    isMobileView ? 'pl-0 col-12' : 'pl-40px col-6',
-                  ])}
-                >
-                  {isBlockVisible(bio) && (
-                  <Bio
-                    bio={bio}
-                    visibilityBio={visibilityBio}
-                    formId="bio"
-                    {...commonFormProps}
-                  />
-                  )}
-
-                  {isBlockVisible((socialLinks || []).some((link) => link?.socialLink !== null)) && (
-                  <SocialLinks
-                    socialLinks={socialLinks || []}
-                    draftSocialLinksByPlatform={draftSocialLinksByPlatform || {}}
-                    visibilitySocialLinks={visibilitySocialLinks}
-                    formId="socialLinks"
-                    {...commonFormProps}
-                  />
-                  )}
-                </div>
-              </div>
+              <BiodataProfileSections />
             </div>
           </div>
           <div
@@ -403,66 +233,6 @@ ProfilePage.propTypes = {
   params: PropTypes.shape({
     username: PropTypes.string.isRequired,
   }).isRequired,
-  requiresParentalConsent: PropTypes.bool,
-  dateJoined: PropTypes.string,
-  username: PropTypes.string,
-  bio: PropTypes.string,
-  visibilityBio: PropTypes.string,
-  courseCertificates: PropTypes.arrayOf(PropTypes.shape({
-    title: PropTypes.string,
-  })),
-  country: PropTypes.string,
-  visibilityCountry: PropTypes.string,
-  levelOfEducation: PropTypes.string,
-  visibilityLevelOfEducation: PropTypes.string,
-  languageProficiencies: PropTypes.arrayOf(PropTypes.shape({
-    code: PropTypes.string.isRequired,
-  })),
-  visibilityLanguageProficiencies: PropTypes.string,
-  name: PropTypes.string,
-  visibilityName: PropTypes.string,
-  socialLinks: PropTypes.arrayOf(PropTypes.shape({
-    platform: PropTypes.string,
-    socialLink: PropTypes.string,
-  })),
-  draftSocialLinksByPlatform: PropTypes.objectOf(PropTypes.shape({
-    platform: PropTypes.string,
-    socialLink: PropTypes.string,
-  })),
-  visibilitySocialLinks: PropTypes.string,
-  profileImage: PropTypes.shape({
-    src: PropTypes.string,
-    isDefault: PropTypes.bool,
-  }),
-  saveState: PropTypes.oneOf([null, 'pending', 'complete', 'error']),
-  savePhotoState: PropTypes.oneOf([null, 'pending', 'complete', 'error']),
-  isLoadingProfile: PropTypes.bool,
-  photoUploadError: PropTypes.objectOf(PropTypes.string),
-};
-
-ProfilePage.defaultProps = {
-  saveState: null,
-  username: '',
-  savePhotoState: null,
-  photoUploadError: {},
-  profileImage: {},
-  name: null,
-  levelOfEducation: null,
-  country: null,
-  socialLinks: [],
-  draftSocialLinksByPlatform: {},
-  bio: null,
-  languageProficiencies: [],
-  courseCertificates: [],
-  requiresParentalConsent: null,
-  dateJoined: null,
-  visibilityName: null,
-  visibilityCountry: null,
-  visibilityLevelOfEducation: null,
-  visibilitySocialLinks: null,
-  visibilityLanguageProficiencies: null,
-  visibilityBio: null,
-  isLoadingProfile: false,
 };
 
 export default withParams(ProfilePage);

--- a/src/profile/biodata/BiodataProfileSections.jsx
+++ b/src/profile/biodata/BiodataProfileSections.jsx
@@ -1,0 +1,205 @@
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import {
+  Card, Collapsible, Nav,
+} from '@openedx/paragon';
+import classNames from 'classnames';
+
+import { BIODATA_SECTIONS } from './config';
+import BiodataSection from './BiodataSection';
+import {
+  openForm, closeForm, saveProfile, updateDraft,
+} from '../data/actions';
+import {
+  getSectionInitialData,
+  getSectionSummary,
+  isSingleMaritalStatus,
+  sectionHasValue,
+} from './utils';
+
+const buildExpandedSectionsState = (sections, openSectionId = null) => sections.reduce(
+  (accumulator, section) => ({
+    ...accumulator,
+    [section.id]: section.id === openSectionId,
+  }),
+  {},
+);
+
+const BiodataProfileSections = () => {
+  const dispatch = useDispatch();
+  const sectionsContainerRef = useRef(null);
+  const {
+    account,
+    drafts,
+    errors,
+    saveState,
+    currentlyEditingField,
+    isAuthenticatedUserProfile,
+  } = useSelector((state) => state.profilePage);
+  const extendedProfile = useMemo(() => account?.extendedProfile || [], [account?.extendedProfile]);
+  const accountUsername = account?.username;
+  const [pendingScrollSection, setPendingScrollSection] = useState(null);
+  const basicInformationData = drafts.basicInformation
+    || getSectionInitialData(BIODATA_SECTIONS[0], extendedProfile);
+  const visibleSections = useMemo(
+    () => BIODATA_SECTIONS.filter((section) => (
+      section.id !== 'spouseInformation' || !isSingleMaritalStatus(basicInformationData.marital_status)
+    )),
+    [basicInformationData.marital_status],
+  );
+
+  const [activeSection, setActiveSection] = useState(BIODATA_SECTIONS[0].id);
+  const [expandedSections, setExpandedSections] = useState(() => (
+    buildExpandedSectionsState(BIODATA_SECTIONS, BIODATA_SECTIONS[0].id)
+  ));
+
+  const sectionSummaries = useMemo(
+    () => BIODATA_SECTIONS.reduce((accumulator, section) => {
+      const savedData = getSectionInitialData(section, extendedProfile);
+      accumulator[section.id] = getSectionSummary(section, savedData);
+      return accumulator;
+    }, {}),
+    [extendedProfile],
+  );
+
+  useEffect(() => {
+    if (visibleSections.some((section) => section.id === activeSection)) {
+      return;
+    }
+
+    const fallbackSectionId = visibleSections[0]?.id || null;
+    setActiveSection(fallbackSectionId);
+    setExpandedSections(buildExpandedSectionsState(visibleSections, fallbackSectionId));
+    setPendingScrollSection(null);
+  }, [activeSection, visibleSections]);
+
+  useEffect(() => {
+    if (!pendingScrollSection || !expandedSections[pendingScrollSection]) {
+      return undefined;
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      const target = document.getElementById(`biodata-section-${pendingScrollSection}`);
+      const container = sectionsContainerRef.current;
+      const sidebarLink = document.querySelector(`[data-biodata-nav="${pendingScrollSection}"]`);
+
+      if (!target || !container || !sidebarLink) {
+        return;
+      }
+
+      const targetTop = target.getBoundingClientRect().top + window.scrollY;
+      const containerTop = container.getBoundingClientRect().top + window.scrollY;
+      const sidebarTop = sidebarLink.getBoundingClientRect().top + window.scrollY;
+      const nextScrollTop = Math.max(
+        window.scrollY + (targetTop - sidebarTop),
+        containerTop - 16,
+      );
+
+      window.scrollTo({
+        top: nextScrollTop,
+        behavior: 'smooth',
+      });
+      setPendingScrollSection(null);
+    }, 250);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [expandedSections, pendingScrollSection]);
+
+  if (!accountUsername) {
+    return null;
+  }
+
+  const openSectionFromSidebar = (sectionId) => {
+    setActiveSection(sectionId);
+    setExpandedSections(buildExpandedSectionsState(visibleSections, sectionId));
+    setPendingScrollSection(sectionId);
+  };
+
+  const toggleSection = (sectionId, isOpen) => {
+    setActiveSection(sectionId);
+    setExpandedSections(buildExpandedSectionsState(visibleSections, isOpen ? sectionId : null));
+  };
+
+  const handleCloseSection = (sectionId) => {
+    dispatch(closeForm(sectionId));
+    setExpandedSections(buildExpandedSectionsState(visibleSections, null));
+  };
+
+  return (
+    <div>
+      <div className="row">
+        <div className="col-lg-3 mb-4 mb-lg-0">
+          <Card className="position-lg-sticky" style={{ top: '0' }}>
+            <Card.Section>
+              <Nav variant="pills" className="flex-column">
+                {visibleSections.map((section) => (
+                  <Nav.Item key={section.id}>
+                    <Nav.Link
+                      active={activeSection === section.id}
+                      data-biodata-nav={section.id}
+                      className="mb-2"
+                      onClick={() => openSectionFromSidebar(section.id)}
+                    >
+                      <div className="font-weight-bold">{section.title}</div>
+                      <div className="small text-muted">{sectionSummaries[section.id]}</div>
+                    </Nav.Link>
+                  </Nav.Item>
+                ))}
+              </Nav>
+            </Card.Section>
+          </Card>
+        </div>
+        <div ref={sectionsContainerRef} className="col-lg-9">
+          {visibleSections.map((section) => (
+            <div key={section.id} id={`biodata-section-${section.id}`} className="mb-3">
+              {(() => {
+                const savedData = getSectionInitialData(section, extendedProfile);
+                const hasSavedContent = sectionHasValue(section, savedData);
+
+                return (
+                  <Collapsible
+                    open={expandedSections[section.id]}
+                    onToggle={(isOpen) => toggleSection(section.id, isOpen)}
+                    title={(
+                      <div className={classNames('d-flex w-100 align-items-center justify-content-between pr-2')}>
+                        <div>
+                          <div className="font-weight-bold text-gray-900">{section.title}</div>
+                          <div className="small text-muted">{section.helperText}</div>
+                        </div>
+                      </div>
+                    )}
+                    styling="card"
+                    className="shadow-sm"
+                  >
+                    <Card.Section>
+                      <BiodataSection
+                        section={section}
+                        extendedProfile={extendedProfile}
+                        draftValue={drafts[section.id]}
+                        errors={errors}
+                        saveState={saveState}
+                        isAuthenticatedUserProfile={isAuthenticatedUserProfile}
+                        isEditing={currentlyEditingField === section.id}
+                        forceEditingWhenEmpty={expandedSections[section.id] && !hasSavedContent}
+                        onOpen={(formId) => dispatch(openForm(formId))}
+                        onClose={handleCloseSection}
+                        onSubmit={(formId) => dispatch(saveProfile(formId, accountUsername))}
+                        onDraftChange={(formId, value) => dispatch(updateDraft(formId, value))}
+                        spacingClassName="pt-0"
+                        showInlineTitle={false}
+                      />
+                    </Card.Section>
+                  </Collapsible>
+                );
+              })()}
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default BiodataProfileSections;

--- a/src/profile/biodata/BiodataProfileSections.jsx
+++ b/src/profile/biodata/BiodataProfileSections.jsx
@@ -9,12 +9,13 @@ import classNames from 'classnames';
 
 import { BIODATA_SECTIONS } from './config';
 import BiodataSection from './BiodataSection';
+import EditButton from '../forms/elements/EditButton';
 import {
   openForm, closeForm, saveProfile, updateDraft,
 } from '../data/actions';
 import {
+  getSanitizedSectionData,
   getSectionInitialData,
-  getSectionSummary,
   isSingleMaritalStatus,
   sectionHasValue,
 } from './utils';
@@ -41,8 +42,10 @@ const BiodataProfileSections = () => {
   const extendedProfile = useMemo(() => account?.extendedProfile || [], [account?.extendedProfile]);
   const accountUsername = account?.username;
   const [pendingScrollSection, setPendingScrollSection] = useState(null);
-  const basicInformationData = drafts.basicInformation
-    || getSectionInitialData(BIODATA_SECTIONS[0], extendedProfile);
+  const basicInformationData = useMemo(() => getSanitizedSectionData(
+    BIODATA_SECTIONS[0],
+    drafts.basicInformation || getSectionInitialData(BIODATA_SECTIONS[0], extendedProfile),
+  ), [drafts.basicInformation, extendedProfile]);
   const visibleSections = useMemo(
     () => BIODATA_SECTIONS.filter((section) => (
       section.id !== 'spouseInformation' || !isSingleMaritalStatus(basicInformationData.marital_status)
@@ -54,15 +57,6 @@ const BiodataProfileSections = () => {
   const [expandedSections, setExpandedSections] = useState(() => (
     buildExpandedSectionsState(BIODATA_SECTIONS, BIODATA_SECTIONS[0].id)
   ));
-
-  const sectionSummaries = useMemo(
-    () => BIODATA_SECTIONS.reduce((accumulator, section) => {
-      const savedData = getSectionInitialData(section, extendedProfile);
-      accumulator[section.id] = getSectionSummary(section, savedData);
-      return accumulator;
-    }, {}),
-    [extendedProfile],
-  );
 
   useEffect(() => {
     if (visibleSections.some((section) => section.id === activeSection)) {
@@ -143,7 +137,6 @@ const BiodataProfileSections = () => {
                       onClick={() => openSectionFromSidebar(section.id)}
                     >
                       <div className="font-weight-bold">{section.title}</div>
-                      <div className="small text-muted">{sectionSummaries[section.id]}</div>
                     </Nav.Link>
                   </Nav.Item>
                 ))}
@@ -168,6 +161,15 @@ const BiodataProfileSections = () => {
                           <div className="font-weight-bold text-gray-900">{section.title}</div>
                           <div className="small text-muted">{section.helperText}</div>
                         </div>
+                        {isAuthenticatedUserProfile && currentlyEditingField !== section.id && (
+                          <EditButton
+                            className="p-1.5"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              dispatch(openForm(section.id));
+                            }}
+                          />
+                        )}
                       </div>
                     )}
                     styling="card"
@@ -183,7 +185,6 @@ const BiodataProfileSections = () => {
                         isAuthenticatedUserProfile={isAuthenticatedUserProfile}
                         isEditing={currentlyEditingField === section.id}
                         forceEditingWhenEmpty={expandedSections[section.id] && !hasSavedContent}
-                        onOpen={(formId) => dispatch(openForm(formId))}
                         onClose={handleCloseSection}
                         onSubmit={(formId) => dispatch(saveProfile(formId, accountUsername))}
                         onDraftChange={(formId, value) => dispatch(updateDraft(formId, value))}

--- a/src/profile/biodata/BiodataSection.jsx
+++ b/src/profile/biodata/BiodataSection.jsx
@@ -1,0 +1,464 @@
+import React, { useMemo } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert, Button, Form, StatefulButton,
+} from '@openedx/paragon';
+
+import EditableItemHeader from '../forms/elements/EditableItemHeader';
+import SwitchContent from '../forms/elements/SwitchContent';
+
+import { PROFILE_FIELD_TYPES } from './config';
+import RepeatableFieldGroup from './RepeatableFieldGroup';
+import {
+  createEmptyRepeatableRow,
+  getSectionError,
+  getSectionInitialData,
+  getSanitizedSectionData,
+  getSectionSummary,
+  isSingleMaritalStatus,
+  readFileAsDataUrl,
+  sectionHasValue,
+} from './utils';
+
+function renderFieldControl(field, value, onChange, error, disabled = false) {
+  if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+    return (
+      <Form.Checkbox
+        checked={Boolean(value)}
+        onChange={(event) => onChange(event.target.checked)}
+        isInvalid={Boolean(error)}
+        disabled={disabled}
+      >
+        {field.label}
+      </Form.Checkbox>
+    );
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.SELECT) {
+    return (
+      <Form.Control
+        as="select"
+        value={value}
+        isInvalid={Boolean(error)}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {(field.options || []).map((option) => (
+          <option key={`${field.fieldName}-${option.value || 'blank'}`} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Form.Control>
+    );
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.TEXTAREA) {
+    return (
+      <Form.Control
+        as="textarea"
+        rows={3}
+        value={value}
+        placeholder={field.placeholder}
+        isInvalid={Boolean(error)}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <Form.Control
+      type={field.type || PROFILE_FIELD_TYPES.TEXT}
+      value={value}
+      placeholder={field.placeholder}
+      isInvalid={Boolean(error)}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}
+
+const BiodataSection = ({
+  section,
+  extendedProfile,
+  draftValue,
+  errors,
+  saveState,
+  isAuthenticatedUserProfile,
+  isEditing,
+  onOpen,
+  onClose,
+  onSubmit,
+  onDraftChange,
+  spacingClassName,
+  showInlineTitle,
+  forceEditingWhenEmpty,
+}) => {
+  const committedData = useMemo(
+    () => getSectionInitialData(section, extendedProfile),
+    [section, extendedProfile],
+  );
+  const formData = draftValue || committedData;
+  const hasContent = sectionHasValue(section, committedData);
+  const sectionError = getSectionError(section, errors);
+
+  if (!isAuthenticatedUserProfile && !hasContent) {
+    return null;
+  }
+
+  let editMode = 'editing';
+  if (!isAuthenticatedUserProfile) {
+    editMode = 'static';
+  } else if (isEditing) {
+    editMode = 'editing';
+  } else if (hasContent) {
+    editMode = 'editable';
+  } else if (forceEditingWhenEmpty) {
+    editMode = 'editing';
+  }
+
+  const handleFieldChange = (fieldName, value) => {
+    const nextFormData = {
+      ...formData,
+      [fieldName]: value,
+    };
+
+    if (section.id === 'basicInformation' && fieldName === 'marital_status' && isSingleMaritalStatus(value)) {
+      nextFormData.number_of_children = '';
+      nextFormData.sons = '';
+      nextFormData.daughters = '';
+    }
+
+    onDraftChange(section.id, getSanitizedSectionData(section, nextFormData));
+  };
+
+  const handleRepeatableChange = (repeatable, action, payload = {}) => {
+    const currentRows = formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)];
+    let nextRows = currentRows;
+
+    if (action === 'addRow') {
+      nextRows = [...currentRows, createEmptyRepeatableRow(repeatable)];
+    } else if (action === 'removeRow') {
+      nextRows = currentRows.filter((_, index) => index !== payload.rowIndex);
+      if (nextRows.length === 0) {
+        nextRows = [createEmptyRepeatableRow(repeatable)];
+      }
+    } else if (action === 'updateCell') {
+      nextRows = currentRows.map((row, index) => (
+        index === payload.rowIndex ? { ...row, [payload.columnKey]: payload.value } : row
+      ));
+    }
+
+    onDraftChange(section.id, {
+      ...formData,
+      [repeatable.storageFieldName]: nextRows,
+    });
+  };
+
+  const handleFileChange = async (fieldName, file) => {
+    if (!file) {
+      return;
+    }
+
+    const dataUrl = await readFileAsDataUrl(file);
+    onDraftChange(section.id, {
+      ...formData,
+      [fieldName]: {
+        name: file.name,
+        dataUrl,
+      },
+    });
+  };
+
+  const handleSectionNaChange = (value) => {
+    onDraftChange(section.id, getSanitizedSectionData(section, {
+      ...formData,
+      [section.naFieldName]: value,
+    }));
+  };
+
+  const handleRepeatableNaChange = (repeatable, value) => {
+    onDraftChange(section.id, getSanitizedSectionData(section, {
+      ...formData,
+      [repeatable.naFieldName]: value,
+    }));
+  };
+
+  const isSectionDisabled = Boolean(section.naFieldName && formData[section.naFieldName]);
+  const visibleFields = (section.fields || []).filter((field) => (
+    section.id !== 'basicInformation'
+    || !['number_of_children', 'sons', 'daughters'].includes(field.fieldName)
+    || !isSingleMaritalStatus(formData.marital_status)
+  ));
+
+  return (
+    <SwitchContent
+      className={spacingClassName}
+      expression={editMode}
+      cases={{
+        editing: (
+          <div role="dialog" aria-labelledby={`${section.id}-label`}>
+            <form onSubmit={(event) => {
+              event.preventDefault();
+              onSubmit(section.id);
+            }}
+            >
+              {showInlineTitle && (
+                <div className="row m-0 pb-1.5 align-items-center">
+                  <p id={`${section.id}-label`} className="h5 font-weight-bold m-0">
+                    {section.title}
+                  </p>
+                </div>
+              )}
+              {showInlineTitle && section.helperText && (
+                <p className="text-muted small mb-3">{section.helperText}</p>
+              )}
+              {sectionError && sectionError.userMessage && (
+                <Alert variant="danger" dismissible={false} show className="mb-3">
+                  {sectionError.userMessage}
+                </Alert>
+              )}
+              {section.naFieldName && (
+                <Form.Group className="mb-3">
+                  <Form.Checkbox
+                    checked={Boolean(formData[section.naFieldName])}
+                    onChange={(event) => handleSectionNaChange(event.target.checked)}
+                  >
+                    {section.naLabel || 'N/A'}
+                  </Form.Checkbox>
+                </Form.Group>
+              )}
+              <div className="row">
+                {visibleFields.map((field) => {
+                  const error = errors[field.fieldName];
+                  return (
+                    <Form.Group
+                      key={field.fieldName}
+                      className={field.type === PROFILE_FIELD_TYPES.TEXTAREA || field.type === PROFILE_FIELD_TYPES.CHECKBOX ? 'col-12 mb-3' : 'col-md-6 mb-3'}
+                    >
+                      {field.type !== PROFILE_FIELD_TYPES.CHECKBOX && (
+                        <Form.Label>{field.label}</Form.Label>
+                      )}
+                      {renderFieldControl(
+                        field,
+                        formData[field.fieldName],
+                        (value) => handleFieldChange(field.fieldName, value),
+                        error,
+                        isSectionDisabled,
+                      )}
+                      {error && error.userMessage && (
+                        <Form.Control.Feedback hasIcon={false}>
+                          {error.userMessage}
+                        </Form.Control.Feedback>
+                      )}
+                    </Form.Group>
+                  );
+                })}
+              </div>
+              {(section.repeatables || []).map((repeatable) => (
+                <div key={repeatable.storageFieldName} className="mb-3">
+                  {repeatable.naFieldName && (
+                    <Form.Group className="mb-2">
+                      <Form.Checkbox
+                        checked={Boolean(formData[repeatable.naFieldName])}
+                        onChange={(event) => handleRepeatableNaChange(repeatable, event.target.checked)}
+                      >
+                        {repeatable.naLabel || 'N/A'}
+                      </Form.Checkbox>
+                    </Form.Group>
+                  )}
+                  <p className="h6 font-weight-bold mb-2">{repeatable.itemLabel}s</p>
+                  <RepeatableFieldGroup
+                    repeatable={repeatable}
+                    rows={formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)]}
+                    onChange={(action, payload) => handleRepeatableChange(repeatable, action, payload)}
+                    disabled={isSectionDisabled || Boolean(repeatable.naFieldName && formData[repeatable.naFieldName])}
+                  />
+                </div>
+              ))}
+              {(section.fileFields || []).map((field) => {
+                const fileValue = formData[field.fieldName];
+                return (
+                  <div key={field.fieldName} className="border rounded p-3 mb-3 bg-light-200">
+                    <p className="h6 font-weight-bold mb-2">{field.label}</p>
+                    <div className="d-flex flex-wrap align-items-center">
+                      <Button
+                        type="button"
+                        size="sm"
+                        variant="outline-primary"
+                        onClick={() => {
+                          const input = document.getElementById(`${section.id}-${field.fieldName}`);
+                          if (input) {
+                            input.click();
+                          }
+                        }}
+                      >
+                        {fileValue ? `Replace ${field.label.toLowerCase()}` : `Upload ${field.label.toLowerCase()}`}
+                      </Button>
+                      {fileValue && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="link"
+                          className="text-danger"
+                          onClick={() => handleFieldChange(field.fieldName, null)}
+                        >
+                          Remove
+                        </Button>
+                      )}
+                    </div>
+                    <input
+                      id={`${section.id}-${field.fieldName}`}
+                      type="file"
+                      accept={field.accept}
+                      className="d-none"
+                      onChange={(event) => {
+                        const input = event.currentTarget;
+                        handleFileChange(field.fieldName, event.target.files && event.target.files[0]);
+                        input.value = '';
+                      }}
+                    />
+                    {fileValue && (
+                      <div className="mt-3">
+                        <img
+                          src={fileValue.dataUrl}
+                          alt={`${field.label} preview`}
+                          className="border rounded p-2 bg-white"
+                          style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
+                        />
+                        <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+              <div className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center">
+                <div className="row form-group flex-shrink-0 flex-grow-1 m-0 p-0">
+                  <div className="pr-2 pl-0 m-0">
+                    <Button variant="outline-primary" type="button" onClick={() => onClose(section.id)}>
+                      Cancel
+                    </Button>
+                  </div>
+                  <div className="p-0 m-0">
+                    <StatefulButton
+                      type="submit"
+                      state={saveState === 'error' ? null : saveState}
+                      labels={{
+                        default: 'Save',
+                        pending: 'Saving',
+                        complete: 'Saved',
+                      }}
+                      disabledStates={[]}
+                    />
+                  </div>
+                </div>
+              </div>
+            </form>
+          </div>
+        ),
+        editable: (
+          <>
+            {showInlineTitle && (
+              <p id={`${section.id}-label`} className="h5 font-weight-bold m-0 pb-1.5">
+                {section.title}
+              </p>
+            )}
+            {showInlineTitle && section.helperText && (
+              <p className="text-muted small mb-2">{section.helperText}</p>
+            )}
+            <EditableItemHeader
+              content={getSectionSummary(section, committedData)}
+              showEditButton
+              onClickEdit={() => onOpen(section.id)}
+            />
+          </>
+        ),
+        static: (
+          <>
+            {showInlineTitle && (
+              <p id={`${section.id}-label`} className="h5 font-weight-bold m-0 pb-1.5">
+                {section.title}
+              </p>
+            )}
+            {showInlineTitle && section.helperText && (
+              <p className="text-muted small mb-2">{section.helperText}</p>
+            )}
+            <EditableItemHeader content={getSectionSummary(section, committedData)} />
+          </>
+        ),
+      }}
+    />
+  );
+};
+
+BiodataSection.propTypes = {
+  section: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    title: PropTypes.string.isRequired,
+    helperText: PropTypes.string,
+    naFieldName: PropTypes.string,
+    naLabel: PropTypes.string,
+    fields: PropTypes.arrayOf(PropTypes.shape({
+      fieldName: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      type: PropTypes.string,
+      placeholder: PropTypes.string,
+    })),
+    repeatables: PropTypes.arrayOf(PropTypes.shape({
+      storageFieldName: PropTypes.string.isRequired,
+      itemLabel: PropTypes.string.isRequired,
+      addButtonLabel: PropTypes.string.isRequired,
+      naFieldName: PropTypes.string,
+      naLabel: PropTypes.string,
+      emptyRow: PropTypes.objectOf(PropTypes.string).isRequired,
+      columns: PropTypes.arrayOf(PropTypes.shape({
+        key: PropTypes.string.isRequired,
+        label: PropTypes.string.isRequired,
+        type: PropTypes.string,
+        placeholder: PropTypes.string,
+      })).isRequired,
+    })),
+    fileFields: PropTypes.arrayOf(PropTypes.shape({
+      fieldName: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      accept: PropTypes.string,
+    })),
+  }).isRequired,
+  extendedProfile: PropTypes.arrayOf(PropTypes.shape({
+    fieldName: PropTypes.string,
+    fieldValue: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+    ]),
+  })),
+  draftValue: PropTypes.shape({}),
+  errors: PropTypes.objectOf(PropTypes.oneOfType([
+    PropTypes.shape({
+      userMessage: PropTypes.string,
+    }),
+    PropTypes.string,
+  ])),
+  saveState: PropTypes.string,
+  isAuthenticatedUserProfile: PropTypes.bool.isRequired,
+  isEditing: PropTypes.bool.isRequired,
+  onOpen: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onDraftChange: PropTypes.func.isRequired,
+  spacingClassName: PropTypes.string,
+  showInlineTitle: PropTypes.bool,
+  forceEditingWhenEmpty: PropTypes.bool,
+};
+
+BiodataSection.defaultProps = {
+  extendedProfile: [],
+  draftValue: null,
+  errors: {},
+  saveState: null,
+  spacingClassName: 'pt-40px',
+  showInlineTitle: true,
+  forceEditingWhenEmpty: false,
+};
+
+export default BiodataSection;

--- a/src/profile/biodata/BiodataSection.jsx
+++ b/src/profile/biodata/BiodataSection.jsx
@@ -4,7 +4,6 @@ import {
   Alert, Button, Form, StatefulButton,
 } from '@openedx/paragon';
 
-import EditableItemHeader from '../forms/elements/EditableItemHeader';
 import SwitchContent from '../forms/elements/SwitchContent';
 
 import { PROFILE_FIELD_TYPES } from './config';
@@ -14,7 +13,6 @@ import {
   getSectionError,
   getSectionInitialData,
   getSanitizedSectionData,
-  getSectionSummary,
   isSingleMaritalStatus,
   readFileAsDataUrl,
   sectionHasValue,
@@ -78,6 +76,30 @@ function renderFieldControl(field, value, onChange, error, disabled = false) {
   );
 }
 
+function renderReadonlyFile(field, fileValue) {
+  if (!fileValue) {
+    return (
+      <div className="border rounded p-3 mb-3 bg-light-200">
+        <p className="h6 font-weight-bold mb-2">{field.label}</p>
+        <p className="small text-muted mb-0">No file uploaded</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded p-3 mb-3 bg-light-200">
+      <p className="h6 font-weight-bold mb-2">{field.label}</p>
+      <img
+        src={fileValue.dataUrl || fileValue.url}
+        alt={`${field.label} preview`}
+        className="border rounded p-2 bg-white"
+        style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
+      />
+      <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
+    </div>
+  );
+}
+
 const BiodataSection = ({
   section,
   extendedProfile,
@@ -86,7 +108,6 @@ const BiodataSection = ({
   saveState,
   isAuthenticatedUserProfile,
   isEditing,
-  onOpen,
   onClose,
   onSubmit,
   onDraftChange,
@@ -98,7 +119,10 @@ const BiodataSection = ({
     () => getSectionInitialData(section, extendedProfile),
     [section, extendedProfile],
   );
-  const formData = draftValue || committedData;
+  const formData = useMemo(
+    () => getSanitizedSectionData(section, draftValue || committedData),
+    [section, draftValue, committedData],
+  );
   const hasContent = sectionHasValue(section, committedData);
   const sectionError = getSectionError(section, errors);
 
@@ -112,7 +136,7 @@ const BiodataSection = ({
   } else if (isEditing) {
     editMode = 'editing';
   } else if (hasContent) {
-    editMode = 'editable';
+    editMode = 'readonly';
   } else if (forceEditingWhenEmpty) {
     editMode = 'editing';
   }
@@ -124,9 +148,9 @@ const BiodataSection = ({
     };
 
     if (section.id === 'basicInformation' && fieldName === 'marital_status' && isSingleMaritalStatus(value)) {
-      nextFormData.number_of_children = '';
-      nextFormData.sons = '';
-      nextFormData.daughters = '';
+      nextFormData.number_of_children = '0';
+      nextFormData.sons = '0';
+      nextFormData.daughters = '0';
     }
 
     onDraftChange(section.id, getSanitizedSectionData(section, nextFormData));
@@ -190,6 +214,134 @@ const BiodataSection = ({
     || !['number_of_children', 'sons', 'daughters'].includes(field.fieldName)
     || !isSingleMaritalStatus(formData.marital_status)
   ));
+  const renderFormFields = (disabled = false) => (
+    <>
+      {section.naFieldName && (
+        <Form.Group className="mb-3">
+          <Form.Checkbox
+            checked={Boolean(formData[section.naFieldName])}
+            onChange={(event) => handleSectionNaChange(event.target.checked)}
+            disabled={disabled}
+          >
+            {section.naLabel || 'N/A'}
+          </Form.Checkbox>
+        </Form.Group>
+      )}
+      <div className="row">
+        {visibleFields.map((field) => {
+          const error = errors[field.fieldName];
+          return (
+            <Form.Group
+              key={field.fieldName}
+              className={field.type === PROFILE_FIELD_TYPES.TEXTAREA || field.type === PROFILE_FIELD_TYPES.CHECKBOX ? 'col-12 mb-3' : 'col-md-6 mb-3'}
+            >
+              {field.type !== PROFILE_FIELD_TYPES.CHECKBOX && (
+                <Form.Label>{field.label}</Form.Label>
+              )}
+              {renderFieldControl(
+                field,
+                formData[field.fieldName],
+                (value) => handleFieldChange(field.fieldName, value),
+                error,
+                disabled || isSectionDisabled,
+              )}
+              {!disabled && error && error.userMessage && (
+                <Form.Control.Feedback hasIcon={false}>
+                  {error.userMessage}
+                </Form.Control.Feedback>
+              )}
+            </Form.Group>
+          );
+        })}
+      </div>
+      {(section.repeatables || []).map((repeatable) => (
+        <div key={repeatable.storageFieldName} className="mb-3">
+          {repeatable.naFieldName && (
+            <Form.Group className="mb-2">
+              <Form.Checkbox
+                checked={Boolean(formData[repeatable.naFieldName])}
+                onChange={(event) => handleRepeatableNaChange(repeatable, event.target.checked)}
+                disabled={disabled}
+              >
+                {repeatable.naLabel || 'N/A'}
+              </Form.Checkbox>
+            </Form.Group>
+          )}
+          <p className="h6 font-weight-bold mb-2">{repeatable.itemLabel}s</p>
+          <RepeatableFieldGroup
+            repeatable={repeatable}
+            rows={formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)]}
+            onChange={(action, payload) => handleRepeatableChange(repeatable, action, payload)}
+            disabled={
+              disabled
+              || isSectionDisabled
+              || Boolean(repeatable.naFieldName && formData[repeatable.naFieldName])
+            }
+          />
+        </div>
+      ))}
+      {(section.fileFields || []).map((field) => {
+        const fileValue = formData[field.fieldName];
+        if (disabled) {
+          return <div key={field.fieldName}>{renderReadonlyFile(field, fileValue)}</div>;
+        }
+
+        return (
+          <div key={field.fieldName} className="border rounded p-3 mb-3 bg-light-200">
+            <p className="h6 font-weight-bold mb-2">{field.label}</p>
+            <div className="d-flex flex-wrap align-items-center">
+              <Button
+                type="button"
+                size="sm"
+                variant="outline-primary"
+                onClick={() => {
+                  const input = document.getElementById(`${section.id}-${field.fieldName}`);
+                  if (input) {
+                    input.click();
+                  }
+                }}
+              >
+                {fileValue ? `Replace ${field.label.toLowerCase()}` : `Upload ${field.label.toLowerCase()}`}
+              </Button>
+              {fileValue && (
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="link"
+                  className="text-danger"
+                  onClick={() => handleFieldChange(field.fieldName, null)}
+                >
+                  Remove
+                </Button>
+              )}
+            </div>
+            <input
+              id={`${section.id}-${field.fieldName}`}
+              type="file"
+              accept={field.accept}
+              className="d-none"
+              onChange={(event) => {
+                const input = event.currentTarget;
+                handleFileChange(field.fieldName, event.target.files && event.target.files[0]);
+                input.value = '';
+              }}
+            />
+            {fileValue && (
+              <div className="mt-3">
+                <img
+                  src={fileValue.dataUrl || fileValue.url}
+                  alt={`${field.label} preview`}
+                  className="border rounded p-2 bg-white"
+                  style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
+                />
+                <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
 
   return (
     <SwitchContent
@@ -218,120 +370,7 @@ const BiodataSection = ({
                   {sectionError.userMessage}
                 </Alert>
               )}
-              {section.naFieldName && (
-                <Form.Group className="mb-3">
-                  <Form.Checkbox
-                    checked={Boolean(formData[section.naFieldName])}
-                    onChange={(event) => handleSectionNaChange(event.target.checked)}
-                  >
-                    {section.naLabel || 'N/A'}
-                  </Form.Checkbox>
-                </Form.Group>
-              )}
-              <div className="row">
-                {visibleFields.map((field) => {
-                  const error = errors[field.fieldName];
-                  return (
-                    <Form.Group
-                      key={field.fieldName}
-                      className={field.type === PROFILE_FIELD_TYPES.TEXTAREA || field.type === PROFILE_FIELD_TYPES.CHECKBOX ? 'col-12 mb-3' : 'col-md-6 mb-3'}
-                    >
-                      {field.type !== PROFILE_FIELD_TYPES.CHECKBOX && (
-                        <Form.Label>{field.label}</Form.Label>
-                      )}
-                      {renderFieldControl(
-                        field,
-                        formData[field.fieldName],
-                        (value) => handleFieldChange(field.fieldName, value),
-                        error,
-                        isSectionDisabled,
-                      )}
-                      {error && error.userMessage && (
-                        <Form.Control.Feedback hasIcon={false}>
-                          {error.userMessage}
-                        </Form.Control.Feedback>
-                      )}
-                    </Form.Group>
-                  );
-                })}
-              </div>
-              {(section.repeatables || []).map((repeatable) => (
-                <div key={repeatable.storageFieldName} className="mb-3">
-                  {repeatable.naFieldName && (
-                    <Form.Group className="mb-2">
-                      <Form.Checkbox
-                        checked={Boolean(formData[repeatable.naFieldName])}
-                        onChange={(event) => handleRepeatableNaChange(repeatable, event.target.checked)}
-                      >
-                        {repeatable.naLabel || 'N/A'}
-                      </Form.Checkbox>
-                    </Form.Group>
-                  )}
-                  <p className="h6 font-weight-bold mb-2">{repeatable.itemLabel}s</p>
-                  <RepeatableFieldGroup
-                    repeatable={repeatable}
-                    rows={formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)]}
-                    onChange={(action, payload) => handleRepeatableChange(repeatable, action, payload)}
-                    disabled={isSectionDisabled || Boolean(repeatable.naFieldName && formData[repeatable.naFieldName])}
-                  />
-                </div>
-              ))}
-              {(section.fileFields || []).map((field) => {
-                const fileValue = formData[field.fieldName];
-                return (
-                  <div key={field.fieldName} className="border rounded p-3 mb-3 bg-light-200">
-                    <p className="h6 font-weight-bold mb-2">{field.label}</p>
-                    <div className="d-flex flex-wrap align-items-center">
-                      <Button
-                        type="button"
-                        size="sm"
-                        variant="outline-primary"
-                        onClick={() => {
-                          const input = document.getElementById(`${section.id}-${field.fieldName}`);
-                          if (input) {
-                            input.click();
-                          }
-                        }}
-                      >
-                        {fileValue ? `Replace ${field.label.toLowerCase()}` : `Upload ${field.label.toLowerCase()}`}
-                      </Button>
-                      {fileValue && (
-                        <Button
-                          type="button"
-                          size="sm"
-                          variant="link"
-                          className="text-danger"
-                          onClick={() => handleFieldChange(field.fieldName, null)}
-                        >
-                          Remove
-                        </Button>
-                      )}
-                    </div>
-                    <input
-                      id={`${section.id}-${field.fieldName}`}
-                      type="file"
-                      accept={field.accept}
-                      className="d-none"
-                      onChange={(event) => {
-                        const input = event.currentTarget;
-                        handleFileChange(field.fieldName, event.target.files && event.target.files[0]);
-                        input.value = '';
-                      }}
-                    />
-                    {fileValue && (
-                      <div className="mt-3">
-                        <img
-                          src={fileValue.dataUrl}
-                          alt={`${field.label} preview`}
-                          className="border rounded p-2 bg-white"
-                          style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
-                        />
-                        <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
-                      </div>
-                    )}
-                  </div>
-                );
-              })}
+              {renderFormFields()}
               <div className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center">
                 <div className="row form-group flex-shrink-0 flex-grow-1 m-0 p-0">
                   <div className="pr-2 pl-0 m-0">
@@ -356,35 +395,15 @@ const BiodataSection = ({
             </form>
           </div>
         ),
-        editable: (
-          <>
-            {showInlineTitle && (
-              <p id={`${section.id}-label`} className="h5 font-weight-bold m-0 pb-1.5">
-                {section.title}
-              </p>
-            )}
-            {showInlineTitle && section.helperText && (
-              <p className="text-muted small mb-2">{section.helperText}</p>
-            )}
-            <EditableItemHeader
-              content={getSectionSummary(section, committedData)}
-              showEditButton
-              onClickEdit={() => onOpen(section.id)}
-            />
-          </>
+        readonly: (
+          <div className="pt-2">
+            {renderFormFields(true)}
+          </div>
         ),
         static: (
-          <>
-            {showInlineTitle && (
-              <p id={`${section.id}-label`} className="h5 font-weight-bold m-0 pb-1.5">
-                {section.title}
-              </p>
-            )}
-            {showInlineTitle && section.helperText && (
-              <p className="text-muted small mb-2">{section.helperText}</p>
-            )}
-            <EditableItemHeader content={getSectionSummary(section, committedData)} />
-          </>
+          <div className="pt-2">
+            {renderFormFields(true)}
+          </div>
         ),
       }}
     />
@@ -442,7 +461,6 @@ BiodataSection.propTypes = {
   saveState: PropTypes.string,
   isAuthenticatedUserProfile: PropTypes.bool.isRequired,
   isEditing: PropTypes.bool.isRequired,
-  onOpen: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
   onSubmit: PropTypes.func.isRequired,
   onDraftChange: PropTypes.func.isRequired,

--- a/src/profile/biodata/RepeatableFieldGroup.jsx
+++ b/src/profile/biodata/RepeatableFieldGroup.jsx
@@ -1,0 +1,122 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Button, Form } from '@openedx/paragon';
+
+import { PROFILE_FIELD_TYPES } from './config';
+
+function renderControl(field, value, onChange, disabled = false) {
+  if (field.type === PROFILE_FIELD_TYPES.SELECT) {
+    return (
+      <Form.Control
+        as="select"
+        value={value}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      >
+        {(field.options || []).map((option) => (
+          <option key={`${field.key}-${option.value || 'blank'}`} value={option.value}>
+            {option.label}
+          </option>
+        ))}
+      </Form.Control>
+    );
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.TEXTAREA) {
+    return (
+      <Form.Control
+        as="textarea"
+        rows={3}
+        value={value}
+        placeholder={field.placeholder}
+        disabled={disabled}
+        onChange={(event) => onChange(event.target.value)}
+      />
+    );
+  }
+
+  return (
+    <Form.Control
+      type={field.type || PROFILE_FIELD_TYPES.TEXT}
+      value={value}
+      placeholder={field.placeholder}
+      disabled={disabled}
+      onChange={(event) => onChange(event.target.value)}
+    />
+  );
+}
+
+const RepeatableFieldGroup = ({
+  repeatable,
+  rows,
+  onChange,
+  disabled,
+}) => (
+  <div>
+    {rows.map((row, rowIndex) => (
+      <div key={row.rowId} className="border rounded p-3 mb-3">
+        <div className="d-flex justify-content-between align-items-center mb-3">
+          <p className="h6 font-weight-bold mb-0">
+            {repeatable.itemLabel} {rowIndex + 1}
+          </p>
+          <Button
+            variant="link"
+            className="p-0 text-danger"
+            type="button"
+            onClick={() => onChange('removeRow', { rowIndex })}
+            disabled={disabled || rows.length === 1}
+          >
+            Remove
+          </Button>
+        </div>
+        <div className="row">
+          {repeatable.columns.map((column) => (
+            <Form.Group
+              key={`${row.rowId}-${column.key}`}
+              className={column.type === PROFILE_FIELD_TYPES.TEXTAREA ? 'col-12 mb-3' : 'col-md-6 mb-3'}
+            >
+              <Form.Label>{column.label}</Form.Label>
+              {renderControl(column, row[column.key], (value) => onChange('updateCell', {
+                rowIndex,
+                columnKey: column.key,
+                value,
+              }), disabled)}
+            </Form.Group>
+          ))}
+        </div>
+      </div>
+    ))}
+    <Button type="button" variant="link" className="p-0" onClick={() => onChange('addRow')} disabled={disabled}>
+      + {repeatable.addButtonLabel}
+    </Button>
+  </div>
+);
+
+RepeatableFieldGroup.propTypes = {
+  repeatable: PropTypes.shape({
+    storageFieldName: PropTypes.string.isRequired,
+    itemLabel: PropTypes.string.isRequired,
+    addButtonLabel: PropTypes.string.isRequired,
+    columns: PropTypes.arrayOf(PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired,
+      placeholder: PropTypes.string,
+      type: PropTypes.string,
+      options: PropTypes.arrayOf(PropTypes.shape({
+        value: PropTypes.string,
+        label: PropTypes.string,
+      })),
+    })).isRequired,
+  }).isRequired,
+  rows: PropTypes.arrayOf(PropTypes.shape({
+    rowId: PropTypes.string.isRequired,
+  })).isRequired,
+  onChange: PropTypes.func.isRequired,
+  disabled: PropTypes.bool,
+};
+
+RepeatableFieldGroup.defaultProps = {
+  disabled: false,
+};
+
+export default RepeatableFieldGroup;

--- a/src/profile/biodata/apiConfig.js
+++ b/src/profile/biodata/apiConfig.js
@@ -1,0 +1,291 @@
+import { BIODATA_SECTION_MAP } from './config';
+
+export const BIODATA_API_DEFAULT_BASE_PATH = '/fbr/api/biodata';
+export const BIODATA_VALIDATE_PATH = 'v1/validate/';
+
+export const BIODATA_SECTION_ENDPOINTS = {
+  basicInformation: {
+    flat: {
+      path: 'v1/basic-information/',
+      fieldMap: {
+        title: 'profile_title',
+        full_name: 'profile_full_name',
+        preferred_name: 'preferred_calling_name',
+        cnic: 'identity_card_number',
+        date_of_birth: 'date_of_birth',
+        place_of_birth: 'place_of_birth',
+        domicile_district: 'district_of_domicile',
+        religion: 'religion',
+        marital_status: 'marital_status',
+        children_count: 'number_of_children',
+        sons_count: 'sons',
+        daughters_count: 'daughters',
+      },
+    },
+  },
+  physicalMedicalInformation: {
+    flat: {
+      path: 'v1/physical-medical/',
+      fieldMap: {
+        medical_checkup_date: 'last_annual_medical_checkup',
+        height: 'height',
+        weight: 'weight',
+      },
+    },
+  },
+  contactInformation: {
+    flat: {
+      path: 'v1/contact-information/',
+      fieldMap: {
+        permanent_address: 'permanent_residential_address',
+        permanent_phone: 'permanent_phone_number',
+        present_address: 'present_residential_address',
+        present_phone: 'present_phone_number',
+        lahore_address: 'contact_address_lahore',
+        lahore_phone: 'lahore_phone_number',
+        mobile: 'mobile_number',
+        email: 'contact_email',
+      },
+    },
+  },
+  education: {
+    repeatables: {
+      education_records: {
+        path: 'v1/education/',
+        fieldMap: {
+          institute: 'educational_institute',
+          attended_from: 'attended_from',
+          attended_to: 'attended_to',
+          examination: 'examination',
+          year_of_passing: 'year_of_passing',
+          grade: 'grade_division',
+          subjects: 'subjects_studied',
+        },
+      },
+    },
+  },
+  achievements: {
+    flat: {
+      path: 'v1/achievements/',
+    },
+  },
+  languages: {
+    repeatables: {
+      language_proficiencies: {
+        path: 'v1/languages/',
+        fieldMap: {
+          language: 'language_name',
+          speaking: 'speaking_proficiency',
+          reading: 'reading_proficiency',
+          writing: 'writing_proficiency',
+        },
+      },
+    },
+  },
+  employment: {
+    flat: {
+      path: 'v1/employment/',
+      fieldMap: {
+        employment_gap_details: 'first_employment_gap_details_after_education',
+      },
+    },
+    repeatables: {
+      employment_records: {
+        path: 'v1/employment-records/',
+        fieldMap: {
+          organization: 'organization_office',
+          designation: 'designation_place_of_posting',
+          from_date: 'from',
+          to_date: 'to',
+        },
+      },
+    },
+  },
+  competitiveExaminations: {
+    repeatables: {
+      competitive_examinations: {
+        path: 'v1/competitive-examinations/',
+        fieldMap: {
+          examination_name: 'examination_name',
+          agency: 'agency_holding_examination',
+          year: 'year',
+          result_details: 'result_details',
+          merit_position: 'merit_position_if_qualified',
+        },
+      },
+    },
+  },
+  cssExamDetails: {
+    flat: {
+      path: 'v1/css-exam-details/',
+      fieldMap: {
+        roll_number: 'css_roll_number',
+        merit_position: 'css_merit_position',
+        service_preferences: 'occupational_service_group_preferences',
+        chances_availed: 'css_chances_availed',
+        applied_forthcoming: 'applied_for_forthcoming_css_exam',
+        intend_forthcoming: 'intend_to_sit_for_forthcoming_css_exam',
+        last_chance: 'last_chance_date_year',
+      },
+    },
+    repeatables: {
+      css_subject_marks: {
+        path: 'v1/css-subject-marks/',
+      },
+    },
+  },
+  governmentServiceDetails: {
+    flat: {
+      path: 'v1/government-service/',
+      fieldMap: {
+        govt_service_date: 'date_joining_any_govt_service_before_csa',
+        dept_name: 'department_name',
+        csa_joining_date: 'date_joining_civil_services_academy_lahore',
+        irs_joining_date: 'date_joining_transfer_inland_revenue_service',
+        has_other_income: 'other_income_source_besides_salary',
+        other_income_details: 'other_income_details',
+      },
+    },
+  },
+  personalInterests: {
+    flat: {
+      path: 'v1/personal-interests/',
+      fieldMap: {
+        games_played: 'games_played',
+        game_awards: 'game_distinctions_awards',
+        hobbies: 'hobbies',
+      },
+    },
+  },
+  foreignVisits: {
+    repeatables: {
+      foreign_visits: {
+        path: 'v1/foreign-visits/',
+        fieldMap: {
+          country: 'country',
+          purpose: 'purpose_of_visit',
+          visit_type: 'self_or_sponsored_visit',
+          from_date: 'from',
+          to_date: 'to',
+        },
+      },
+    },
+  },
+  familyInformation: {
+    flat: {
+      path: 'v1/family-information/',
+      fieldMap: {
+        father_name: 'father_name',
+        father_education: 'father_education',
+        father_occupation: 'father_occupation',
+        father_address: 'father_address_phone_number',
+        mother_name: 'mother_name',
+        mother_education: 'mother_education',
+        mother_occupation: 'mother_occupation',
+        mother_address: 'mother_address_phone_number',
+      },
+    },
+    repeatables: {
+      siblings_family_information: {
+        path: 'v1/siblings/',
+        fieldMap: {
+          relationship: 'relationship',
+          name: 'name',
+          education: 'education',
+          occupation: 'occupation',
+          address: 'address',
+        },
+      },
+    },
+  },
+  closeRelativesInGovernmentService: {
+    repeatables: {
+      close_relatives_in_government_service: {
+        path: 'v1/government-relatives/',
+      },
+    },
+  },
+  spouseInformation: {
+    flat: {
+      path: 'v1/spouse-information/',
+      fieldMap: {
+        spouse_name: 'spouse_name',
+        spouse_education: 'spouse_education',
+        spouse_occupation: 'spouse_occupation',
+        spouse_address: 'spouse_address_phone_number',
+      },
+    },
+  },
+  declaration: {
+    flat: {
+      path: 'v1/declaration/',
+      fieldMap: {
+        confirmed: 'declaration_confirmed',
+        date: 'declaration_date',
+        signature: 'declaration_signature',
+      },
+    },
+  },
+};
+
+export function getSectionEndpointConfig(sectionId) {
+  return BIODATA_SECTION_ENDPOINTS[sectionId] || null;
+}
+
+export function getSectionRepeatableEndpointConfig(sectionId, storageFieldName) {
+  return getSectionEndpointConfig(sectionId)?.repeatables?.[storageFieldName] || null;
+}
+
+export function getSectionFlatFieldNames(section) {
+  const sectionEndpointConfig = getSectionEndpointConfig(section.id);
+  const baseFieldNames = [
+    ...((section.fields || []).map(({ fieldName }) => fieldName)),
+    ...((section.fileFields || []).map(({ fieldName }) => fieldName)),
+  ];
+  const extraFieldNames = sectionEndpointConfig?.flat?.extraFieldNames || [];
+
+  return [...new Set([...baseFieldNames, ...extraFieldNames])];
+}
+
+export function getFlatUiToApiFieldMap(sectionId) {
+  const fieldMap = getSectionEndpointConfig(sectionId)?.flat?.fieldMap || {};
+
+  return Object.entries(fieldMap).reduce((accumulator, [apiFieldName, uiFieldName]) => {
+    accumulator[uiFieldName] = apiFieldName;
+    return accumulator;
+  }, {});
+}
+
+export function getFlatApiToUiFieldMap(sectionId) {
+  return getSectionEndpointConfig(sectionId)?.flat?.fieldMap || {};
+}
+
+export function getRepeatableExtraFieldNames(sectionId, storageFieldName) {
+  return getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.extraFieldNames || [];
+}
+
+export function getSectionRepeatableConfigs(section) {
+  return (section.repeatables || []).map((repeatable) => ({
+    repeatable,
+    endpoint: getSectionRepeatableEndpointConfig(section.id, repeatable.storageFieldName),
+  })).filter(({ endpoint }) => Boolean(endpoint));
+}
+
+export function getRepeatableUiToApiFieldMap(sectionId, storageFieldName) {
+  const fieldMap = getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap || {};
+
+  return Object.entries(fieldMap).reduce((accumulator, [apiFieldName, uiFieldName]) => {
+    accumulator[uiFieldName] = apiFieldName;
+    return accumulator;
+  }, {});
+}
+
+export function getRepeatableApiToUiFieldMap(sectionId, storageFieldName) {
+  return getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap || {};
+}
+
+export function getConfiguredBiodataSections() {
+  return Object.keys(BIODATA_SECTION_ENDPOINTS)
+    .map(sectionId => BIODATA_SECTION_MAP[sectionId])
+    .filter(Boolean);
+}

--- a/src/profile/biodata/apiTransforms.js
+++ b/src/profile/biodata/apiTransforms.js
@@ -1,0 +1,391 @@
+import {
+  getConfiguredBiodataSections,
+  getFlatUiToApiFieldMap,
+  getRepeatableExtraFieldNames,
+  getFlatApiToUiFieldMap,
+  getRepeatableApiToUiFieldMap,
+  getRepeatableUiToApiFieldMap,
+  getSectionFlatFieldNames,
+  getSectionRepeatableConfigs,
+} from './apiConfig';
+import {
+  PROFILE_FIELD_TYPES,
+  BIODATA_SECTION_MAP,
+} from './config';
+import {
+  createEmptyRepeatableRow,
+  getSanitizedSectionData,
+  isSingleMaritalStatus,
+} from './utils';
+
+const FILE_FIELD_KEYS = ['name', 'dataUrl', 'url', 'imageUrl', 'previewUrl'];
+const YES_NO_FIELD_NAMES = [
+  'applied_for_forthcoming_css_exam',
+  'intend_to_sit_for_forthcoming_css_exam',
+  'other_income_source_besides_salary',
+];
+
+function normalizeMessage(errorValue) {
+  if (Array.isArray(errorValue)) {
+    return errorValue.join(' ');
+  }
+
+  if (typeof errorValue === 'string') {
+    return errorValue;
+  }
+
+  if (errorValue && typeof errorValue === 'object') {
+    if (typeof errorValue.userMessage === 'string') {
+      return errorValue.userMessage;
+    }
+    if (typeof errorValue.message === 'string') {
+      return errorValue.message;
+    }
+    if (Array.isArray(errorValue.detail)) {
+      return errorValue.detail.join(' ');
+    }
+    if (typeof errorValue.detail === 'string') {
+      return errorValue.detail;
+    }
+  }
+
+  return 'Unable to save this section.';
+}
+
+function normalizeFieldError(errorValue) {
+  if (errorValue && typeof errorValue === 'object' && typeof errorValue.userMessage === 'string') {
+    return errorValue;
+  }
+
+  return {
+    userMessage: normalizeMessage(errorValue),
+  };
+}
+
+function extractErrorMap(errorData) {
+  if (!errorData || typeof errorData !== 'object') {
+    return {};
+  }
+
+  if (errorData.errors && typeof errorData.errors === 'object') {
+    return errorData.errors;
+  }
+
+  if (errorData.fieldErrors && typeof errorData.fieldErrors === 'object') {
+    return errorData.fieldErrors;
+  }
+
+  return errorData;
+}
+
+function normalizeFileValue(value) {
+  if (!value) {
+    return null;
+  }
+
+  if (typeof value === 'string') {
+    return {
+      name: value.split('/').pop() || 'file',
+      url: value,
+    };
+  }
+
+  if (typeof value === 'object') {
+    const normalizedValue = {};
+    FILE_FIELD_KEYS.forEach((key) => {
+      if (value[key]) {
+        normalizedValue[key] = value[key];
+      }
+    });
+
+    if (Object.keys(normalizedValue).length > 0) {
+      return {
+        ...normalizedValue,
+        name: normalizedValue.name || value.fileName || value.filename || 'file',
+        url: normalizedValue.url || value.fileUrl || value.imageUrl || null,
+      };
+    }
+  }
+
+  return null;
+}
+
+function normalizeRepeatableRow(row, repeatable, uiToApiFieldMap = {}) {
+  const normalizedRow = repeatable.columns.reduce((accumulator, column) => {
+    const apiFieldName = uiToApiFieldMap[column.key] || column.key;
+    accumulator[column.key] = row?.[apiFieldName] == null ? '' : String(row[apiFieldName]);
+    return accumulator;
+  }, {});
+
+  if (row?.id != null) {
+    normalizedRow.backendId = row.id;
+  } else if (row?.backendId != null) {
+    normalizedRow.backendId = row.backendId;
+  }
+
+  return normalizedRow;
+}
+
+function pickDefinedFields(source = {}, fieldNames = []) {
+  return fieldNames.reduce((accumulator, fieldName) => {
+    if (source[fieldName] !== undefined) {
+      accumulator[fieldName] = source[fieldName];
+    }
+    return accumulator;
+  }, {});
+}
+
+function coerceFlatFieldValue(section, fieldName, value) {
+  const field = [
+    ...(section.fields || []),
+    ...(section.fileFields || []),
+  ].find(item => item.fieldName === fieldName);
+
+  if (!field) {
+    return value;
+  }
+
+  if (section.fileFields?.some(item => item.fieldName === fieldName)) {
+    return normalizeFileValue(value);
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+    return Boolean(value);
+  }
+
+  if (YES_NO_FIELD_NAMES.includes(fieldName)) {
+    if (value === true) {
+      return 'Yes';
+    }
+    if (value === false) {
+      return 'No';
+    }
+    return '';
+  }
+
+  return value == null ? '' : String(value);
+}
+
+function normalizeFlatPayloadValue(fieldName, value) {
+  if (YES_NO_FIELD_NAMES.includes(fieldName)) {
+    if (value === 'Yes') {
+      return true;
+    }
+    if (value === 'No') {
+      return false;
+    }
+    return null;
+  }
+
+  return value;
+}
+
+export function normalizeBiodataErrorForSection(error, sectionId = null) {
+  const processedError = Object.create(error);
+  const errorData = error?.response?.data;
+  const flatApiToUiFieldMap = sectionId ? getFlatApiToUiFieldMap(sectionId) : {};
+  const repeatableApiToUiFieldMaps = sectionId
+    ? getSectionRepeatableConfigs(BIODATA_SECTION_MAP[sectionId] || {})
+      .reduce((accumulator, { repeatable }) => ({
+        ...accumulator,
+        ...getRepeatableApiToUiFieldMap(sectionId, repeatable.storageFieldName),
+      }), {})
+    : {};
+
+  if (!errorData || typeof errorData !== 'object') {
+    return error;
+  }
+
+  const normalizedFieldErrors = Object.entries(extractErrorMap(errorData)).reduce((accumulator, [fieldName, value]) => {
+    accumulator[
+      flatApiToUiFieldMap[fieldName]
+      || repeatableApiToUiFieldMaps[fieldName]
+      || fieldName
+    ] = normalizeFieldError(value);
+    return accumulator;
+  }, {});
+
+  processedError.processedData = {
+    fieldErrors: normalizedFieldErrors,
+  };
+
+  return processedError;
+}
+
+export function normalizeBiodataError(error) {
+  return normalizeBiodataErrorForSection(error);
+}
+
+function buildSectionEntries(section, flatResponse = {}, repeatableResponsesByKey = {}) {
+  const flatFieldNames = getSectionFlatFieldNames(section);
+  const flatApiToUiFieldMap = getFlatApiToUiFieldMap(section.id);
+  const flatEntries = flatFieldNames.map((fieldName) => ({
+    fieldName,
+    fieldValue: coerceFlatFieldValue(
+      section,
+      fieldName,
+      flatResponse[getFlatUiToApiFieldMap(section.id)[fieldName] || fieldName]
+        ?? flatResponse[flatApiToUiFieldMap[fieldName] || fieldName],
+    ),
+  }));
+
+  const repeatableEntries = getSectionRepeatableConfigs(section).map(({ repeatable }) => {
+    const uiToApiFieldMap = getRepeatableUiToApiFieldMap(section.id, repeatable.storageFieldName);
+
+    return {
+      fieldName: repeatable.storageFieldName,
+      fieldValue: (repeatableResponsesByKey[repeatable.storageFieldName] || [])
+        .map(row => normalizeRepeatableRow(row, repeatable, uiToApiFieldMap)),
+    };
+  });
+
+  const repeatableExtraEntries = getSectionRepeatableConfigs(section)
+    .flatMap(({ repeatable }) => getRepeatableExtraFieldNames(section.id, repeatable.storageFieldName)
+      .map((fieldName) => ({
+        fieldName,
+        fieldValue: Boolean(flatResponse[fieldName] ?? false),
+      })));
+
+  return [...flatEntries, ...repeatableEntries, ...repeatableExtraEntries];
+}
+
+function getSectionFieldNames(section) {
+  return buildSectionEntries(section).map(entry => entry.fieldName);
+}
+
+export function buildBiodataExtendedProfile(flatResponsesBySection = {}, repeatableResponsesByKey = {}) {
+  return getConfiguredBiodataSections().flatMap((section) => (
+    buildSectionEntries(section, flatResponsesBySection[section.id] || {}, repeatableResponsesByKey)
+  ));
+}
+
+export function buildSectionExtendedProfile(sectionId, flatResponse = {}, repeatableResponsesByKey = {}) {
+  const section = BIODATA_SECTION_MAP[sectionId];
+
+  if (!section) {
+    return [];
+  }
+
+  return buildSectionEntries(section, flatResponse, repeatableResponsesByKey);
+}
+
+export function mergeSectionIntoExtendedProfile(sectionId, currentExtendedProfile = [], sectionEntries = []) {
+  const section = BIODATA_SECTION_MAP[sectionId];
+
+  if (!section) {
+    return currentExtendedProfile;
+  }
+
+  const sectionFieldNames = new Set(getSectionFieldNames(section));
+
+  return [
+    ...(currentExtendedProfile || []).filter(entry => !sectionFieldNames.has(entry.fieldName)),
+    ...sectionEntries,
+  ];
+}
+
+export function mapSectionDataToFlatPayload(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+  const fieldNames = getSectionFlatFieldNames(section);
+  const flatUiToApiFieldMap = getFlatUiToApiFieldMap(section.id);
+
+  return fieldNames.reduce((accumulator, fieldName) => {
+    if (sanitizedData[fieldName] === undefined) {
+      return accumulator;
+    }
+
+    const apiFieldName = flatUiToApiFieldMap[fieldName] || fieldName;
+    accumulator[apiFieldName] = normalizeFlatPayloadValue(fieldName, sanitizedData[fieldName]);
+    return accumulator;
+  }, {});
+}
+
+export function mapSectionDataToRepeatablePayloads(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+
+  return getSectionRepeatableConfigs(section).map(({ repeatable, endpoint }) => ({
+    repeatable,
+    endpoint,
+    extraFields: pickDefinedFields(
+      sanitizedData,
+      getRepeatableExtraFieldNames(section.id, repeatable.storageFieldName),
+    ),
+    rows: (sanitizedData[repeatable.storageFieldName] || [])
+      .filter((row) => repeatable.columns.some(({ key }) => String(row?.[key] || '').trim().length > 0))
+      .map((row) => ({
+        backendId: row.backendId ?? row.id ?? null,
+        values: repeatable.columns.reduce((accumulator, { key }) => {
+          const apiFieldName = getRepeatableUiToApiFieldMap(section.id, repeatable.storageFieldName)[key] || key;
+          accumulator[apiFieldName] = row?.[key] ?? '';
+          return accumulator;
+        }, {}),
+      })),
+  }));
+}
+
+export function buildSectionDraftFromExtendedProfile(sectionId, extendedProfile) {
+  const section = BIODATA_SECTION_MAP[sectionId];
+
+  if (!section) {
+    return {};
+  }
+
+  const fieldMap = (extendedProfile || []).reduce((accumulator, entry) => {
+    accumulator[entry.fieldName] = entry.fieldValue;
+    return accumulator;
+  }, {});
+
+  const baseDraft = {
+    ...(section.naFieldName ? { [section.naFieldName]: Boolean(fieldMap[section.naFieldName]) } : {}),
+    ...((section.fields || []).reduce((accumulator, field) => {
+      accumulator[field.fieldName] = coerceFlatFieldValue(section, field.fieldName, fieldMap[field.fieldName]);
+      return accumulator;
+    }, {})),
+    ...((section.fileFields || []).reduce((accumulator, field) => {
+      accumulator[field.fieldName] = normalizeFileValue(fieldMap[field.fieldName]);
+      return accumulator;
+    }, {})),
+  };
+
+  const repeatableDraft = (section.repeatables || []).reduce((accumulator, repeatable) => {
+    const uiToApiFieldMap = getRepeatableUiToApiFieldMap(sectionId, repeatable.storageFieldName);
+    const rows = Array.isArray(fieldMap[repeatable.storageFieldName])
+      ? fieldMap[repeatable.storageFieldName].map(row => normalizeRepeatableRow(row, repeatable, uiToApiFieldMap))
+      : [];
+
+    accumulator[repeatable.storageFieldName] = rows.length > 0
+      ? rows
+      : [createEmptyRepeatableRow(repeatable)];
+
+    if (repeatable.naFieldName) {
+      accumulator[repeatable.naFieldName] = Boolean(fieldMap[repeatable.naFieldName]);
+    }
+
+    return accumulator;
+  }, {});
+
+  const draft = {
+    ...baseDraft,
+    ...repeatableDraft,
+  };
+
+  if (sectionId === 'basicInformation' && isSingleMaritalStatus(draft.marital_status)) {
+    draft.number_of_children = '';
+    draft.sons = '';
+    draft.daughters = '';
+  }
+
+  return getSanitizedSectionData(section, draft);
+}
+
+export function buildValidationPayload(section, sectionData) {
+  return {
+    section: section.id,
+    flat: mapSectionDataToFlatPayload(section, sectionData),
+    repeatables: mapSectionDataToRepeatablePayloads(section, sectionData).map((item) => ({
+      path: item.endpoint.path,
+      extraFields: item.extraFields,
+      rows: item.rows,
+    })),
+  };
+}

--- a/src/profile/biodata/config.js
+++ b/src/profile/biodata/config.js
@@ -1,0 +1,448 @@
+export const PROFILE_FIELD_TYPES = {
+  TEXT: 'text',
+  DATE: 'date',
+  NUMBER: 'number',
+  TEXTAREA: 'textarea',
+  SELECT: 'select',
+  CHECKBOX: 'checkbox',
+};
+
+const YES_NO_OPTIONS = [
+  { value: '', label: 'Select option' },
+  { value: 'Yes', label: 'Yes' },
+  { value: 'No', label: 'No' },
+];
+
+const TITLE_OPTIONS = [
+  { value: '', label: 'Select title' },
+  { value: 'Mr', label: 'Mr' },
+  { value: 'Mrs', label: 'Mrs' },
+  { value: 'Ms', label: 'Ms' },
+  { value: 'Miss', label: 'Miss' },
+];
+
+const MARITAL_STATUS_OPTIONS = [
+  { value: '', label: 'Select marital status' },
+  { value: 'Single', label: 'Single' },
+  { value: 'Married', label: 'Married' },
+  { value: 'Widowed', label: 'Widowed' },
+  { value: 'Divorced', label: 'Divorced' },
+];
+
+const PROFICIENCY_OPTIONS = [
+  { value: '', label: 'Select proficiency' },
+  { value: 'Basic', label: 'Basic' },
+  { value: 'Intermediate', label: 'Intermediate' },
+  { value: 'Advanced', label: 'Advanced' },
+  { value: 'Native', label: 'Native' },
+];
+
+export const BIODATA_SECTIONS = [
+  {
+    id: 'basicInformation',
+    title: 'Basic Information',
+    helperText: 'Core personal biodata details.',
+    fields: [
+      {
+        fieldName: 'profile_title', label: 'Title', type: PROFILE_FIELD_TYPES.SELECT, options: TITLE_OPTIONS,
+      },
+      { fieldName: 'profile_full_name', label: 'Full Name', placeholder: 'Enter full name' },
+      { fieldName: 'preferred_calling_name', label: 'Preferred / calling name', placeholder: 'Enter preferred name' },
+      { fieldName: 'identity_card_number', label: 'Identity Card Number', placeholder: 'Enter identity card number' },
+      { fieldName: 'date_of_birth', label: 'Date of Birth', type: PROFILE_FIELD_TYPES.DATE },
+      { fieldName: 'place_of_birth', label: 'Place of Birth', placeholder: 'Enter place of birth' },
+      { fieldName: 'district_of_domicile', label: 'District of Domicile', placeholder: 'Enter district of domicile' },
+      { fieldName: 'religion', label: 'Religion', placeholder: 'Enter religion' },
+      {
+        fieldName: 'marital_status', label: 'Marital Status', type: PROFILE_FIELD_TYPES.SELECT, options: MARITAL_STATUS_OPTIONS,
+      },
+      {
+        fieldName: 'number_of_children', label: 'Number of Children', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
+      },
+      {
+        fieldName: 'sons', label: 'Sons', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
+      },
+      {
+        fieldName: 'daughters', label: 'Daughters', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
+      },
+    ],
+  },
+  {
+    id: 'physicalMedicalInformation',
+    title: 'Physical / Medical Information',
+    helperText: 'Medical checkup date and physical details.',
+    fields: [
+      { fieldName: 'last_annual_medical_checkup', label: 'Date of last annual medical checkup', type: PROFILE_FIELD_TYPES.DATE },
+      { fieldName: 'height', label: 'Height', placeholder: 'Enter height' },
+      { fieldName: 'weight', label: 'Weight', placeholder: 'Enter weight' },
+    ],
+  },
+  {
+    id: 'contactInformation',
+    title: 'Contact Information',
+    helperText: 'Addresses, phones, and email details.',
+    fields: [
+      {
+        fieldName: 'permanent_residential_address', label: 'Permanent residential address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter permanent residential address',
+      },
+      { fieldName: 'permanent_phone_number', label: 'Permanent phone number', placeholder: 'Enter permanent phone number' },
+      {
+        fieldName: 'present_residential_address', label: 'Present residential address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter present residential address',
+      },
+      { fieldName: 'present_phone_number', label: 'Present phone number', placeholder: 'Enter present phone number' },
+      {
+        fieldName: 'contact_address_lahore', label: 'Contact address at Lahore', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter Lahore contact address',
+      },
+      { fieldName: 'lahore_phone_number', label: 'Lahore phone number', placeholder: 'Enter Lahore phone number' },
+      { fieldName: 'mobile_number', label: 'Mobile number', placeholder: 'Enter mobile number' },
+      { fieldName: 'contact_email', label: 'Email', placeholder: 'Enter email address' },
+    ],
+  },
+  {
+    id: 'education',
+    title: 'Education',
+    helperText: 'Academic record in repeatable rows.',
+    repeatables: [
+      {
+        storageFieldName: 'education_records',
+        addButtonLabel: 'Add education record',
+        itemLabel: 'Education record',
+        emptyRow: {
+          educational_institute: '',
+          attended_from: '',
+          attended_to: '',
+          examination: '',
+          year_of_passing: '',
+          grade_division: '',
+          subjects_studied: '',
+        },
+        columns: [
+          { key: 'educational_institute', label: 'Educational Institute', placeholder: 'Enter educational institute' },
+          { key: 'attended_from', label: 'Attended From', type: PROFILE_FIELD_TYPES.DATE },
+          { key: 'attended_to', label: 'Attended To', type: PROFILE_FIELD_TYPES.DATE },
+          { key: 'examination', label: 'Examination', placeholder: 'Enter examination' },
+          { key: 'year_of_passing', label: 'Year of Passing', placeholder: 'Enter year of passing' },
+          { key: 'grade_division', label: 'Grade / Division', placeholder: 'Enter grade or division' },
+          {
+            key: 'subjects_studied', label: 'Subjects Studied', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter subjects studied',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'achievements',
+    title: 'Achievements',
+    helperText: 'Distinctions, scholarships, and awards.',
+    naFieldName: 'achievements_not_applicable',
+    naLabel: 'N/A',
+    fields: [
+      {
+        fieldName: 'distinctions', label: 'Distinctions', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter distinctions',
+      },
+      {
+        fieldName: 'scholarships', label: 'Scholarships', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter scholarships',
+      },
+      {
+        fieldName: 'awards', label: 'Awards', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter awards',
+      },
+    ],
+  },
+  {
+    id: 'languages',
+    title: 'Languages',
+    helperText: 'Language proficiency in speaking, reading, and writing.',
+    repeatables: [
+      {
+        storageFieldName: 'language_proficiencies',
+        addButtonLabel: 'Add language',
+        itemLabel: 'Language',
+        emptyRow: {
+          language_name: '',
+          speaking_proficiency: '',
+          reading_proficiency: '',
+          writing_proficiency: '',
+        },
+        columns: [
+          { key: 'language_name', label: 'Language name', placeholder: 'Enter language name' },
+          {
+            key: 'speaking_proficiency', label: 'Speaking proficiency', type: PROFILE_FIELD_TYPES.SELECT, options: PROFICIENCY_OPTIONS,
+          },
+          {
+            key: 'reading_proficiency', label: 'Reading proficiency', type: PROFILE_FIELD_TYPES.SELECT, options: PROFICIENCY_OPTIONS,
+          },
+          {
+            key: 'writing_proficiency', label: 'Writing proficiency', type: PROFILE_FIELD_TYPES.SELECT, options: PROFICIENCY_OPTIONS,
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'employment',
+    title: 'Employment',
+    helperText: 'Employment gap details and record.',
+    naFieldName: 'employment_not_applicable',
+    naLabel: 'N/A',
+    fields: [
+      {
+        fieldName: 'first_employment_gap_details_after_education', label: 'First employment gap details after education', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter employment gap details',
+      },
+    ],
+    repeatables: [
+      {
+        storageFieldName: 'employment_records',
+        addButtonLabel: 'Add employment record',
+        itemLabel: 'Employment record',
+        emptyRow: {
+          organization_office: '',
+          designation_place_of_posting: '',
+          from: '',
+          to: '',
+        },
+        columns: [
+          { key: 'organization_office', label: 'Organization / Office', placeholder: 'Enter organization or office' },
+          { key: 'designation_place_of_posting', label: 'Designation & Place of Posting', placeholder: 'Enter designation and place of posting' },
+          { key: 'from', label: 'From', type: PROFILE_FIELD_TYPES.DATE },
+          { key: 'to', label: 'To', type: PROFILE_FIELD_TYPES.DATE },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'competitiveExaminations',
+    title: 'Competitive Examinations',
+    helperText: 'Competitive exams and results.',
+    naFieldName: 'competitive_examinations_not_applicable',
+    naLabel: 'N/A',
+    repeatables: [
+      {
+        storageFieldName: 'competitive_examinations',
+        addButtonLabel: 'Add examination',
+        itemLabel: 'Competitive examination',
+        emptyRow: {
+          examination_name: '',
+          agency_holding_examination: '',
+          year: '',
+          result_details: '',
+          merit_position_if_qualified: '',
+        },
+        columns: [
+          { key: 'examination_name', label: 'Examination name', placeholder: 'Enter examination name' },
+          { key: 'agency_holding_examination', label: 'Agency holding examination', placeholder: 'Enter agency name' },
+          { key: 'year', label: 'Year', placeholder: 'Enter year' },
+          {
+            key: 'result_details', label: 'Result details', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter result details',
+          },
+          { key: 'merit_position_if_qualified', label: 'Merit position, if qualified', placeholder: 'Enter merit position' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'cssExamDetails',
+    title: 'CSS Exam Details',
+    helperText: 'CSS summary, preferences, and marks.',
+    fields: [
+      { fieldName: 'css_roll_number', label: 'CSS Roll Number', placeholder: 'Enter CSS roll number' },
+      { fieldName: 'css_merit_position', label: 'CSS Merit Position', placeholder: 'Enter CSS merit position' },
+      {
+        fieldName: 'occupational_service_group_preferences', label: 'Occupational / Service Group Preferences', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter occupational or service group preferences',
+      },
+      {
+        fieldName: 'css_chances_availed', label: 'CSS chances availed', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
+      },
+      {
+        fieldName: 'applied_for_forthcoming_css_exam', label: 'Applied for forthcoming CSS exam', type: PROFILE_FIELD_TYPES.SELECT, options: YES_NO_OPTIONS,
+      },
+      {
+        fieldName: 'intend_to_sit_for_forthcoming_css_exam', label: 'Intend to sit for forthcoming CSS exam', type: PROFILE_FIELD_TYPES.SELECT, options: YES_NO_OPTIONS,
+      },
+      { fieldName: 'last_chance_date_year', label: 'Last chance date / year', placeholder: 'Enter last chance date or year' },
+    ],
+    repeatables: [
+      {
+        storageFieldName: 'css_subject_marks',
+        addButtonLabel: 'Add subject mark',
+        itemLabel: 'Subject mark',
+        emptyRow: {
+          subject: '',
+          total_marks: '',
+          marks_obtained: '',
+        },
+        columns: [
+          { key: 'subject', label: 'Subject', placeholder: 'Enter subject' },
+          { key: 'total_marks', label: 'Total Marks', placeholder: 'Enter total marks' },
+          { key: 'marks_obtained', label: 'Marks Obtained', placeholder: 'Enter marks obtained' },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'governmentServiceDetails',
+    title: 'Government Service Details',
+    helperText: 'Dates, department, service, and income details.',
+    fields: [
+      { fieldName: 'date_joining_any_govt_service_before_csa', label: 'Date of joining any Govt. Service before CSA', type: PROFILE_FIELD_TYPES.DATE },
+      { fieldName: 'department_name', label: 'Department name', placeholder: 'Enter department name' },
+      { fieldName: 'date_joining_civil_services_academy_lahore', label: 'Date of joining Civil Services Academy, Lahore', type: PROFILE_FIELD_TYPES.DATE },
+      { fieldName: 'date_joining_transfer_inland_revenue_service', label: 'Date of joining / transfer to Inland Revenue Service', type: PROFILE_FIELD_TYPES.DATE },
+      {
+        fieldName: 'other_income_source_besides_salary', label: 'Other income source besides salary', type: PROFILE_FIELD_TYPES.SELECT, options: YES_NO_OPTIONS,
+      },
+      {
+        fieldName: 'other_income_details', label: 'Other income details', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter other income details',
+      },
+    ],
+  },
+  {
+    id: 'personalInterests',
+    title: 'Personal Interests',
+    helperText: 'Games, distinctions, and hobbies.',
+    fields: [
+      {
+        fieldName: 'games_played', label: 'Games played', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter games played',
+      },
+      {
+        fieldName: 'game_distinctions_awards', label: 'Game distinctions / awards', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter game distinctions or awards',
+      },
+      {
+        fieldName: 'hobbies', label: 'Hobbies', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter hobbies',
+      },
+    ],
+  },
+  {
+    id: 'foreignVisits',
+    title: 'Foreign Visits',
+    helperText: 'Travel history in repeatable rows.',
+    naFieldName: 'foreign_visits_not_applicable',
+    naLabel: 'N/A',
+    repeatables: [
+      {
+        storageFieldName: 'foreign_visits',
+        addButtonLabel: 'Add foreign visit',
+        itemLabel: 'Foreign visit',
+        emptyRow: {
+          country: '',
+          purpose_of_visit: '',
+          self_or_sponsored_visit: '',
+          from: '',
+          to: '',
+        },
+        columns: [
+          { key: 'country', label: 'Country', placeholder: 'Enter country' },
+          { key: 'purpose_of_visit', label: 'Purpose of visit', placeholder: 'Enter purpose of visit' },
+          { key: 'self_or_sponsored_visit', label: 'Self or sponsored visit', placeholder: 'Enter self or sponsored' },
+          { key: 'from', label: 'From', type: PROFILE_FIELD_TYPES.DATE },
+          { key: 'to', label: 'To', type: PROFILE_FIELD_TYPES.DATE },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'familyInformation',
+    title: 'Family Information',
+    helperText: 'Parents and siblings details.',
+    fields: [
+      { fieldName: 'father_name', label: 'Father Name', placeholder: 'Enter father name' },
+      { fieldName: 'father_education', label: 'Father Education', placeholder: 'Enter father education' },
+      { fieldName: 'father_occupation', label: 'Father Occupation', placeholder: 'Enter father occupation' },
+      {
+        fieldName: 'father_address_phone_number', label: 'Father Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter father address and phone number',
+      },
+      { fieldName: 'mother_name', label: 'Mother Name', placeholder: 'Enter mother name' },
+      { fieldName: 'mother_education', label: 'Mother Education', placeholder: 'Enter mother education' },
+      { fieldName: 'mother_occupation', label: 'Mother Occupation', placeholder: 'Enter mother occupation' },
+      {
+        fieldName: 'mother_address_phone_number', label: 'Mother Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter mother address and phone number',
+      },
+    ],
+    repeatables: [
+      {
+        storageFieldName: 'siblings_family_information',
+        addButtonLabel: 'Add family member',
+        itemLabel: 'Brother / Sister',
+        naFieldName: 'siblings_not_applicable',
+        naLabel: 'N/A',
+        emptyRow: {
+          relationship: '',
+          name: '',
+          education: '',
+          occupation: '',
+          address_phone_number: '',
+        },
+        columns: [
+          { key: 'relationship', label: 'Relationship', placeholder: 'Enter brother or sister' },
+          { key: 'name', label: 'Name', placeholder: 'Enter name' },
+          { key: 'education', label: 'Education', placeholder: 'Enter education' },
+          { key: 'occupation', label: 'Occupation', placeholder: 'Enter occupation' },
+          {
+            key: 'address_phone_number', label: 'Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter address and phone number',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'closeRelativesInGovernmentService',
+    title: 'Close Relatives in Government Service',
+    helperText: 'Government service relatives in repeatable rows.',
+    naFieldName: 'close_relatives_in_government_service_not_applicable',
+    naLabel: 'N/A',
+    repeatables: [
+      {
+        storageFieldName: 'close_relatives_in_government_service',
+        addButtonLabel: 'Add relative',
+        itemLabel: 'Relative',
+        emptyRow: {
+          relative_name: '',
+          designation: '',
+          relationship: '',
+          address: '',
+        },
+        columns: [
+          { key: 'relative_name', label: 'Relative Name', placeholder: 'Enter relative name' },
+          { key: 'designation', label: 'Designation', placeholder: 'Enter designation' },
+          { key: 'relationship', label: 'Relationship', placeholder: 'Enter relationship' },
+          {
+            key: 'address', label: 'Address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter address',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'spouseInformation',
+    title: 'Spouse Information',
+    helperText: 'Spouse education, occupation, and address.',
+    fields: [
+      { fieldName: 'spouse_name', label: 'Spouse Name', placeholder: 'Enter spouse name' },
+      { fieldName: 'spouse_education', label: 'Spouse Education', placeholder: 'Enter spouse education' },
+      { fieldName: 'spouse_occupation', label: 'Spouse Occupation', placeholder: 'Enter spouse occupation' },
+      {
+        fieldName: 'spouse_address_phone_number', label: 'Spouse Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter spouse address and phone number',
+      },
+    ],
+  },
+  {
+    id: 'declaration',
+    title: 'Declaration',
+    helperText: 'Confirm the information and add a signature image if needed.',
+    fields: [
+      { fieldName: 'declaration_confirmed', label: 'I confirm that the information provided is correct.', type: PROFILE_FIELD_TYPES.CHECKBOX },
+      { fieldName: 'declaration_date', label: 'Date', type: PROFILE_FIELD_TYPES.DATE },
+    ],
+    fileFields: [
+      {
+        fieldName: 'declaration_signature',
+        label: 'Signature',
+        accept: '.jpg,.jpeg,.png,.webp',
+      },
+    ],
+  },
+];
+
+export const BIODATA_SECTION_MAP = BIODATA_SECTIONS.reduce((accumulator, section) => {
+  accumulator[section.id] = section;
+  return accumulator;
+}, {});

--- a/src/profile/biodata/config.js
+++ b/src/profile/biodata/config.js
@@ -15,26 +15,26 @@ const YES_NO_OPTIONS = [
 
 const TITLE_OPTIONS = [
   { value: '', label: 'Select title' },
-  { value: 'Mr', label: 'Mr' },
-  { value: 'Mrs', label: 'Mrs' },
-  { value: 'Ms', label: 'Ms' },
-  { value: 'Miss', label: 'Miss' },
+  { value: 'mr', label: 'Mr' },
+  { value: 'mrs', label: 'Mrs' },
+  { value: 'ms', label: 'Ms' },
+  { value: 'miss', label: 'Miss' },
 ];
 
 const MARITAL_STATUS_OPTIONS = [
   { value: '', label: 'Select marital status' },
-  { value: 'Single', label: 'Single' },
-  { value: 'Married', label: 'Married' },
-  { value: 'Widowed', label: 'Widowed' },
-  { value: 'Divorced', label: 'Divorced' },
+  { value: 'single', label: 'Single' },
+  { value: 'married', label: 'Married' },
+  { value: 'widowed', label: 'Widowed' },
+  { value: 'divorced', label: 'Divorced' },
 ];
 
 const PROFICIENCY_OPTIONS = [
   { value: '', label: 'Select proficiency' },
-  { value: 'Basic', label: 'Basic' },
-  { value: 'Intermediate', label: 'Intermediate' },
-  { value: 'Advanced', label: 'Advanced' },
-  { value: 'Native', label: 'Native' },
+  { value: 'basic', label: 'Basic' },
+  { value: 'intermediate', label: 'Intermediate' },
+  { value: 'advanced', label: 'Advanced' },
+  { value: 'native', label: 'Native' },
 ];
 
 export const BIODATA_SECTIONS = [
@@ -369,7 +369,7 @@ export const BIODATA_SECTIONS = [
           name: '',
           education: '',
           occupation: '',
-          address_phone_number: '',
+          address: '',
         },
         columns: [
           { key: 'relationship', label: 'Relationship', placeholder: 'Enter brother or sister' },
@@ -377,7 +377,7 @@ export const BIODATA_SECTIONS = [
           { key: 'education', label: 'Education', placeholder: 'Enter education' },
           { key: 'occupation', label: 'Occupation', placeholder: 'Enter occupation' },
           {
-            key: 'address_phone_number', label: 'Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter address and phone number',
+            key: 'address', label: 'Address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter address',
           },
         ],
       },
@@ -395,13 +395,13 @@ export const BIODATA_SECTIONS = [
         addButtonLabel: 'Add relative',
         itemLabel: 'Relative',
         emptyRow: {
-          relative_name: '',
+          name: '',
           designation: '',
           relationship: '',
           address: '',
         },
         columns: [
-          { key: 'relative_name', label: 'Relative Name', placeholder: 'Enter relative name' },
+          { key: 'name', label: 'Relative Name', placeholder: 'Enter relative name' },
           { key: 'designation', label: 'Designation', placeholder: 'Enter designation' },
           { key: 'relationship', label: 'Relationship', placeholder: 'Enter relationship' },
           {

--- a/src/profile/biodata/utils.js
+++ b/src/profile/biodata/utils.js
@@ -19,6 +19,8 @@ function buildRepeatableRow(row, repeatableConfig) {
 
   return {
     ...normalizedRow,
+    ...(row?.backendId != null ? { backendId: row.backendId } : {}),
+    ...(row?.id != null ? { backendId: row.id } : {}),
     rowId: `row-${repeatableRowCounter}`,
   };
 }
@@ -29,7 +31,7 @@ export function getExtendedProfileValue(extendedProfile, fieldName) {
 }
 
 export function isSingleMaritalStatus(value) {
-  return String(value || '').trim() === 'Single';
+  return String(value || '').trim().toLowerCase() === 'single';
 }
 
 export function normalizeFieldValue(field, storedValue) {
@@ -42,6 +44,13 @@ export function normalizeFieldValue(field, storedValue) {
 
 export function parseRepeatableRows(storedValue, repeatableConfig) {
   if (!storedValue) {
+    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+  }
+
+  if (Array.isArray(storedValue)) {
+    if (storedValue.length > 0) {
+      return storedValue.map((row) => buildRepeatableRow(row, repeatableConfig));
+    }
     return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
   }
 
@@ -58,14 +67,21 @@ export function parseRepeatableRows(storedValue, repeatableConfig) {
 }
 
 export function serializeRepeatableRows(rows, repeatableConfig) {
-  return JSON.stringify(
-    (rows || [])
-      .map((row) => repeatableConfig.columns.reduce((accumulator, column) => {
+  return JSON.stringify((rows || [])
+    .map((row) => {
+      const normalizedRow = repeatableConfig.columns.reduce((accumulator, column) => {
         accumulator[column.key] = String((row && row[column.key]) || '').trim();
         return accumulator;
-      }, {}))
-      .filter((row) => Object.values(row).some((value) => value.length > 0)),
-  );
+      }, {});
+
+      if (row?.backendId != null) {
+        normalizedRow.backendId = row.backendId;
+      }
+
+      return normalizedRow;
+    })
+    .filter((row) => Object.entries(row)
+      .some(([key, value]) => key === 'backendId' || value.length > 0)));
 }
 
 export function parseFileFieldValue(storedValue) {
@@ -73,27 +89,46 @@ export function parseFileFieldValue(storedValue) {
     return null;
   }
 
+  if (typeof storedValue === 'object') {
+    if (storedValue.name && (storedValue.dataUrl || storedValue.url)) {
+      return {
+        name: String(storedValue.name),
+        ...(storedValue.dataUrl ? { dataUrl: String(storedValue.dataUrl) } : {}),
+        ...(storedValue.url ? { url: String(storedValue.url) } : {}),
+      };
+    }
+    return null;
+  }
+
   try {
     const parsed = JSON.parse(storedValue);
-    if (parsed && parsed.name && parsed.dataUrl) {
+    if (parsed && parsed.name && (parsed.dataUrl || parsed.url)) {
       return {
         name: String(parsed.name),
-        dataUrl: String(parsed.dataUrl),
+        ...(parsed.dataUrl ? { dataUrl: String(parsed.dataUrl) } : {}),
+        ...(parsed.url ? { url: String(parsed.url) } : {}),
       };
     }
   } catch (error) {
-    return null;
+    return {
+      name: String(storedValue).split('/').pop() || 'file',
+      url: String(storedValue),
+    };
   }
 
   return null;
 }
 
 export function serializeFileFieldValue(fileValue) {
-  if (!fileValue || !fileValue.name || !fileValue.dataUrl) {
+  if (!fileValue || !fileValue.name || (!fileValue.dataUrl && !fileValue.url)) {
     return '';
   }
 
-  return JSON.stringify(fileValue);
+  return JSON.stringify({
+    name: fileValue.name,
+    ...(fileValue.dataUrl ? { dataUrl: fileValue.dataUrl } : {}),
+    ...(fileValue.url ? { url: fileValue.url } : {}),
+  });
 }
 
 export function readFileAsDataUrl(file) {
@@ -176,7 +211,7 @@ export function getSanitizedSectionData(section, sectionData) {
 
   if (section.id === 'basicInformation' && isSingleMaritalStatus(sanitizedData.marital_status)) {
     BASIC_INFORMATION_CHILD_FIELD_NAMES.forEach((fieldName) => {
-      sanitizedData[fieldName] = '';
+      sanitizedData[fieldName] = '0';
     });
   }
 

--- a/src/profile/biodata/utils.js
+++ b/src/profile/biodata/utils.js
@@ -1,0 +1,346 @@
+import { BIODATA_SECTION_MAP, PROFILE_FIELD_TYPES } from './config';
+
+let repeatableRowCounter = 0;
+const BASIC_INFORMATION_CHILD_FIELD_NAMES = ['number_of_children', 'sons', 'daughters'];
+const SPOUSE_FIELD_NAMES = [
+  'spouse_name',
+  'spouse_education',
+  'spouse_occupation',
+  'spouse_address_phone_number',
+];
+
+function buildRepeatableRow(row, repeatableConfig) {
+  const normalizedRow = repeatableConfig.columns.reduce((accumulator, column) => {
+    accumulator[column.key] = String((row && row[column.key]) || '');
+    return accumulator;
+  }, {});
+
+  repeatableRowCounter += 1;
+
+  return {
+    ...normalizedRow,
+    rowId: `row-${repeatableRowCounter}`,
+  };
+}
+
+export function getExtendedProfileValue(extendedProfile, fieldName) {
+  const field = (extendedProfile || []).find((item) => item.fieldName === fieldName);
+  return field ? field.fieldValue : '';
+}
+
+export function isSingleMaritalStatus(value) {
+  return String(value || '').trim() === 'Single';
+}
+
+export function normalizeFieldValue(field, storedValue) {
+  if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+    return String(storedValue).toLowerCase() === 'true';
+  }
+
+  return String(storedValue || '');
+}
+
+export function parseRepeatableRows(storedValue, repeatableConfig) {
+  if (!storedValue) {
+    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue);
+    if (Array.isArray(parsed) && parsed.length > 0) {
+      return parsed.map((row) => buildRepeatableRow(row, repeatableConfig));
+    }
+  } catch (error) {
+    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+  }
+
+  return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+}
+
+export function serializeRepeatableRows(rows, repeatableConfig) {
+  return JSON.stringify(
+    (rows || [])
+      .map((row) => repeatableConfig.columns.reduce((accumulator, column) => {
+        accumulator[column.key] = String((row && row[column.key]) || '').trim();
+        return accumulator;
+      }, {}))
+      .filter((row) => Object.values(row).some((value) => value.length > 0)),
+  );
+}
+
+export function parseFileFieldValue(storedValue) {
+  if (!storedValue) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue);
+    if (parsed && parsed.name && parsed.dataUrl) {
+      return {
+        name: String(parsed.name),
+        dataUrl: String(parsed.dataUrl),
+      };
+    }
+  } catch (error) {
+    return null;
+  }
+
+  return null;
+}
+
+export function serializeFileFieldValue(fileValue) {
+  if (!fileValue || !fileValue.name || !fileValue.dataUrl) {
+    return '';
+  }
+
+  return JSON.stringify(fileValue);
+}
+
+export function readFileAsDataUrl(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(reader.result);
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}
+
+export function getSectionInitialData(section, extendedProfile) {
+  const fieldValues = (section.fields || []).reduce((accumulator, field) => {
+    accumulator[field.fieldName] = normalizeFieldValue(
+      field,
+      getExtendedProfileValue(extendedProfile, field.fieldName),
+    );
+    return accumulator;
+  }, {});
+
+  const repeatableValues = (section.repeatables || []).reduce((accumulator, repeatable) => {
+    accumulator[repeatable.storageFieldName] = parseRepeatableRows(
+      getExtendedProfileValue(extendedProfile, repeatable.storageFieldName),
+      repeatable,
+    );
+    return accumulator;
+  }, {});
+
+  const fileValues = (section.fileFields || []).reduce((accumulator, field) => {
+    accumulator[field.fieldName] = parseFileFieldValue(
+      getExtendedProfileValue(extendedProfile, field.fieldName),
+    );
+    return accumulator;
+  }, {});
+
+  const toggleValues = [
+    ...(section.naFieldName ? [{ fieldName: section.naFieldName, type: PROFILE_FIELD_TYPES.CHECKBOX }] : []),
+    ...((section.repeatables || [])
+      .filter((repeatable) => repeatable.naFieldName)
+      .map((repeatable) => ({
+        fieldName: repeatable.naFieldName,
+        type: PROFILE_FIELD_TYPES.CHECKBOX,
+      }))),
+  ].reduce((accumulator, field) => {
+    accumulator[field.fieldName] = normalizeFieldValue(
+      field,
+      getExtendedProfileValue(extendedProfile, field.fieldName),
+    );
+    return accumulator;
+  }, {});
+
+  return {
+    ...toggleValues,
+    ...fieldValues,
+    ...repeatableValues,
+    ...fileValues,
+  };
+}
+
+export function getSanitizedSectionData(section, sectionData) {
+  const sanitizedData = { ...sectionData };
+
+  if (section.naFieldName && sanitizedData[section.naFieldName]) {
+    (section.fields || []).forEach((field) => {
+      sanitizedData[field.fieldName] = field.type === PROFILE_FIELD_TYPES.CHECKBOX ? false : '';
+    });
+    (section.repeatables || []).forEach((repeatable) => {
+      sanitizedData[repeatable.storageFieldName] = [buildRepeatableRow(repeatable.emptyRow, repeatable)];
+    });
+    (section.fileFields || []).forEach((field) => {
+      sanitizedData[field.fieldName] = null;
+    });
+  }
+
+  (section.repeatables || []).forEach((repeatable) => {
+    if (repeatable.naFieldName && sanitizedData[repeatable.naFieldName]) {
+      sanitizedData[repeatable.storageFieldName] = [buildRepeatableRow(repeatable.emptyRow, repeatable)];
+    }
+  });
+
+  if (section.id === 'basicInformation' && isSingleMaritalStatus(sanitizedData.marital_status)) {
+    BASIC_INFORMATION_CHILD_FIELD_NAMES.forEach((fieldName) => {
+      sanitizedData[fieldName] = '';
+    });
+  }
+
+  return sanitizedData;
+}
+
+export function getSectionPayload(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+
+  return [
+    ...(section.naFieldName ? [{
+      fieldName: section.naFieldName,
+      fieldValue: String(Boolean(sanitizedData[section.naFieldName])),
+    }] : []),
+    ...((section.repeatables || [])
+      .filter((repeatable) => repeatable.naFieldName)
+      .map((repeatable) => ({
+        fieldName: repeatable.naFieldName,
+        fieldValue: String(Boolean(sanitizedData[repeatable.naFieldName])),
+      }))),
+    ...(section.fields || []).map((field) => ({
+      fieldName: field.fieldName,
+      fieldValue: field.type === PROFILE_FIELD_TYPES.CHECKBOX
+        ? String(Boolean(sanitizedData[field.fieldName]))
+        : String(sanitizedData[field.fieldName] || '').trim(),
+    })),
+    ...(section.repeatables || []).map((repeatable) => ({
+      fieldName: repeatable.storageFieldName,
+      fieldValue: serializeRepeatableRows(sanitizedData[repeatable.storageFieldName] || [], repeatable),
+    })),
+    ...(section.fileFields || []).map((field) => ({
+      fieldName: field.fieldName,
+      fieldValue: serializeFileFieldValue(sanitizedData[field.fieldName]),
+    })),
+    ...(section.id === 'basicInformation' && isSingleMaritalStatus(sanitizedData.marital_status)
+      ? SPOUSE_FIELD_NAMES.map((fieldName) => ({
+        fieldName,
+        fieldValue: '',
+      }))
+      : []),
+  ];
+}
+
+export function getSectionById(sectionId) {
+  return BIODATA_SECTION_MAP[sectionId] || null;
+}
+
+function rowHasUserValue(row, repeatable) {
+  return repeatable.columns.some((column) => String(row[column.key] || '').trim().length > 0);
+}
+
+export function sectionHasValue(section, sectionData) {
+  if (section.naFieldName && Boolean(sectionData[section.naFieldName])) {
+    return true;
+  }
+
+  const hasRepeatableNaState = (section.repeatables || []).some((repeatable) => (
+    repeatable.naFieldName && Boolean(sectionData[repeatable.naFieldName])
+  ));
+
+  if (hasRepeatableNaState) {
+    return true;
+  }
+
+  const hasFieldValue = (section.fields || []).some((field) => {
+    if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+      return Boolean(sectionData[field.fieldName]);
+    }
+    return String(sectionData[field.fieldName] || '').trim().length > 0;
+  });
+
+  if (hasFieldValue) {
+    return true;
+  }
+
+  const hasRepeatableValue = (section.repeatables || []).some((repeatable) => (
+    (sectionData[repeatable.storageFieldName] || []).some((row) => (
+      rowHasUserValue(row, repeatable)
+    ))
+  ));
+
+  if (hasRepeatableValue) {
+    return true;
+  }
+
+  return (section.fileFields || []).some((field) => Boolean(sectionData[field.fieldName]));
+}
+
+export function getSectionSummary(section, sectionData) {
+  if (section.naFieldName && Boolean(sectionData[section.naFieldName])) {
+    return 'N/A';
+  }
+
+  const firstFilledField = (section.fields || []).find((field) => {
+    if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+      return Boolean(sectionData[field.fieldName]);
+    }
+    return String(sectionData[field.fieldName] || '').trim().length > 0;
+  });
+
+  if (firstFilledField) {
+    if (firstFilledField.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+      return firstFilledField.label;
+    }
+
+    return String(sectionData[firstFilledField.fieldName]).trim();
+  }
+
+  for (let index = 0; index < (section.repeatables || []).length; index += 1) {
+    const repeatable = section.repeatables[index];
+    const filledRows = (sectionData[repeatable.storageFieldName] || [])
+      .filter((row) => rowHasUserValue(row, repeatable));
+
+    if (filledRows.length > 0) {
+      const previewColumn = repeatable.columns.find((column) => (
+        String(filledRows[0][column.key] || '').trim().length > 0
+      ));
+      const previewValue = previewColumn ? String(filledRows[0][previewColumn.key]).trim() : repeatable.itemLabel;
+
+      if (filledRows.length > 1) {
+        return `${previewValue} +${filledRows.length - 1} more`;
+      }
+      return previewValue;
+    }
+  }
+
+  const uploadedFile = (section.fileFields || []).find((field) => Boolean(sectionData[field.fieldName]));
+  if (uploadedFile) {
+    return sectionData[uploadedFile.fieldName].name || uploadedFile.label;
+  }
+
+  const hasRepeatableNaState = (section.repeatables || []).some((repeatable) => (
+    repeatable.naFieldName && Boolean(sectionData[repeatable.naFieldName])
+  ));
+  if (hasRepeatableNaState) {
+    return 'N/A';
+  }
+
+  return 'No information added';
+}
+
+export function getSectionError(section, errors) {
+  const fieldError = (section.fields || []).find((field) => errors[field.fieldName]);
+  if (fieldError) {
+    return errors[fieldError.fieldName];
+  }
+
+  const repeatableError = (section.repeatables || []).find((repeatable) => errors[repeatable.storageFieldName]);
+  if (repeatableError) {
+    return errors[repeatableError.storageFieldName];
+  }
+
+  const fileError = (section.fileFields || []).find((field) => errors[field.fieldName]);
+  if (fileError) {
+    return errors[fileError.fieldName];
+  }
+
+  return errors.extendedProfile || errors[section.id] || null;
+}
+
+export function isBiodataForm(formId) {
+  return Boolean(getSectionById(formId));
+}
+
+export function createEmptyRepeatableRow(repeatableConfig) {
+  return buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig);
+}

--- a/src/profile/data/reducers.js
+++ b/src/profile/data/reducers.js
@@ -17,6 +17,7 @@ export const initialState = {
   account: {
     socialLinks: [],
     languageProficiencies: [],
+    extendedProfile: [],
     name: '',
     bio: '',
     country: '',

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -32,6 +32,7 @@ import {
 } from './actions';
 import { handleSaveProfileSelector, userAccountSelector } from './selectors';
 import * as ProfileApiService from './services';
+import { getSectionById, getSectionInitialData, getSectionPayload } from '../biodata/utils';
 
 export function* handleFetchProfile(action) {
   const { username } = action.payload;
@@ -98,9 +99,10 @@ export function* handleFetchProfile(action) {
 
 export function* handleSaveProfile(action) {
   try {
-    const { drafts, preferences } = yield select(handleSaveProfileSelector);
+    const { drafts, preferences, account } = yield select(handleSaveProfileSelector);
+    const biodataSection = getSectionById(action.payload.formId);
 
-    const accountDrafts = pick(drafts, [
+    let accountDrafts = pick(drafts, [
       'bio',
       'country',
       'levelOfEducation',
@@ -109,7 +111,7 @@ export function* handleSaveProfile(action) {
       'socialLinks',
     ]);
 
-    const preferencesDrafts = pick(drafts, [
+    let preferencesDrafts = pick(drafts, [
       'visibilityBio',
       'visibilityCountry',
       'visibilityLevelOfEducation',
@@ -117,6 +119,16 @@ export function* handleSaveProfile(action) {
       'visibilityName',
       'visibilitySocialLinks',
     ]);
+
+    if (biodataSection) {
+      const sectionDraft = drafts[action.payload.formId]
+        || getSectionInitialData(biodataSection, account.extendedProfile || []);
+
+      accountDrafts = {
+        extendedProfile: getSectionPayload(biodataSection, sectionDraft),
+      };
+      preferencesDrafts = {};
+    }
 
     if (Object.keys(preferencesDrafts).length > 0) {
       preferencesDrafts.accountPrivacy = 'custom';

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -32,7 +32,8 @@ import {
 } from './actions';
 import { handleSaveProfileSelector, userAccountSelector } from './selectors';
 import * as ProfileApiService from './services';
-import { getSectionById, getSectionInitialData, getSectionPayload } from '../biodata/utils';
+import { getSectionById } from '../biodata/utils';
+import { buildSectionDraftFromExtendedProfile } from '../biodata/apiTransforms';
 
 export function* handleFetchProfile(action) {
   const { username } = action.payload;
@@ -42,6 +43,7 @@ export function* handleFetchProfile(action) {
   let account = userAccount;
   let courseCertificates = null;
   let countriesCodesList = [];
+  let biodataExtendedProfile = [];
 
   try {
     yield put(fetchProfileBegin());
@@ -54,12 +56,17 @@ export function* handleFetchProfile(action) {
 
     if (isAuthenticatedUserProfile) {
       calls.push(call(ProfileApiService.getPreferences, username));
+      calls.push(call(ProfileApiService.getBiodataProfile));
     }
 
     const result = yield all(calls);
 
     if (isAuthenticatedUserProfile) {
-      [account, courseCertificates, countriesCodesList, preferences] = result;
+      [account, courseCertificates, countriesCodesList, preferences, biodataExtendedProfile] = result;
+      account = {
+        ...account,
+        extendedProfile: biodataExtendedProfile,
+      };
     } else {
       [account, courseCertificates, countriesCodesList] = result;
     }
@@ -120,29 +127,39 @@ export function* handleSaveProfile(action) {
       'visibilitySocialLinks',
     ]);
 
+    yield put(saveProfileBegin());
+
     if (biodataSection) {
       const sectionDraft = drafts[action.payload.formId]
-        || getSectionInitialData(biodataSection, account.extendedProfile || []);
+        || buildSectionDraftFromExtendedProfile(action.payload.formId, account.extendedProfile || []);
+      const committedSectionData = buildSectionDraftFromExtendedProfile(
+        action.payload.formId,
+        account.extendedProfile || [],
+      );
 
-      accountDrafts = {
-        extendedProfile: getSectionPayload(biodataSection, sectionDraft),
-      };
+      accountDrafts = yield call(
+        ProfileApiService.saveBiodataSection,
+        action.payload.formId,
+        sectionDraft,
+        committedSectionData,
+        account.extendedProfile || [],
+      );
       preferencesDrafts = {};
     }
 
     if (Object.keys(preferencesDrafts).length > 0) {
       preferencesDrafts.accountPrivacy = 'custom';
     }
-
-    yield put(saveProfileBegin());
     let accountResult = null;
 
-    if (Object.keys(accountDrafts).length > 0) {
+    if (Object.keys(accountDrafts).length > 0 && !biodataSection) {
       accountResult = yield call(
         ProfileApiService.patchProfile,
         action.payload.username,
         accountDrafts,
       );
+    } else if (Object.keys(accountDrafts).length > 0) {
+      accountResult = accountDrafts;
     }
 
     let preferencesResult = preferences;

--- a/src/profile/data/sagas.test.js
+++ b/src/profile/data/sagas.test.js
@@ -18,6 +18,9 @@ jest.mock('./services', () => ({
   deleteProfilePhoto: jest.fn(),
   getPreferences: jest.fn(),
   getAccount: jest.fn(),
+  getBiodataProfile: jest.fn(),
+  saveBiodataSection: jest.fn(),
+  validateBiodataSection: jest.fn(),
   getCourseCertificates: jest.fn(),
   getCountryList: jest.fn(),
 }));
@@ -68,7 +71,8 @@ describe('RootSaga', () => {
       const action = profileActions.fetchProfile('gonzo');
       const gen = handleFetchProfile(action);
 
-      const result = [userAccount, [1, 2, 3], [], { preferences: 'stuff' }];
+      const biodata = [{ fieldName: 'profile_full_name', fieldValue: 'Gonzo' }];
+      const result = [userAccount, [1, 2, 3], [], { preferences: 'stuff' }, biodata];
 
       expect(gen.next().value).toEqual(select(userAccountSelector));
       expect(gen.next(selectorData).value).toEqual(put(profileActions.fetchProfileBegin()));
@@ -77,9 +81,13 @@ describe('RootSaga', () => {
         call(ProfileApiService.getCourseCertificates, 'gonzo'),
         call(ProfileApiService.getCountryList),
         call(ProfileApiService.getPreferences, 'gonzo'),
+        call(ProfileApiService.getBiodataProfile),
       ]));
       expect(gen.next(result).value)
-        .toEqual(put(profileActions.fetchProfileSuccess(userAccount, result[3], result[1], true, [])));
+        .toEqual(put(profileActions.fetchProfileSuccess({
+          ...userAccount,
+          extendedProfile: biodata,
+        }, result[3], result[1], true, [])));
       expect(gen.next().value).toEqual(put(profileActions.fetchProfileReset()));
       expect(gen.next().value).toBeUndefined();
     });
@@ -121,6 +129,9 @@ describe('RootSaga', () => {
         name: 'Full Name',
       },
       preferences: {},
+      account: {
+        extendedProfile: [],
+      },
     };
 
     it('should successfully process a saveProfile request if there are no exceptions', () => {
@@ -142,6 +153,49 @@ describe('RootSaga', () => {
       expect(gen.next().value).toEqual(put(profileActions.saveProfileReset()));
       expect(gen.next().value).toEqual(put(profileActions.resetDrafts()));
       expect(gen.next().value).toBeUndefined();
+    });
+
+    it('should save a biodata section through the biodata service flow', () => {
+      const action = profileActions.saveProfile('basicInformation', 'my username');
+      const gen = handleSaveProfile(action);
+      const selectorPayload = {
+        ...selectorData,
+        drafts: {
+          basicInformation: {
+            profile_full_name: 'Full Name',
+          },
+        },
+        account: {
+          extendedProfile: [],
+        },
+      };
+      const savedAccount = {
+        extendedProfile: [{ fieldName: 'profile_full_name', fieldValue: 'Full Name' }],
+      };
+
+      expect(gen.next().value).toEqual(select(handleSaveProfileSelector));
+      expect(gen.next(selectorPayload).value).toEqual(put(profileActions.saveProfileBegin()));
+      expect(gen.next().value).toEqual(call(
+        ProfileApiService.saveBiodataSection,
+        'basicInformation',
+        selectorPayload.drafts.basicInformation,
+        {
+          daughters: '',
+          date_of_birth: '',
+          district_of_domicile: '',
+          identity_card_number: '',
+          marital_status: '',
+          number_of_children: '',
+          place_of_birth: '',
+          preferred_calling_name: '',
+          profile_full_name: '',
+          profile_title: '',
+          religion: '',
+          sons: '',
+        },
+        [],
+      ));
+      expect(gen.next(savedAccount).value).toEqual(put(profileActions.saveProfileSuccess(savedAccount, {})));
     });
 
     it('should successfully publish a failure action on exception', () => {

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -151,9 +151,11 @@ export const profileImageSelector = createSelector(
 export const handleSaveProfileSelector = createSelector(
   profileDraftsSelector,
   profilePreferencesSelector,
-  (drafts, preferences) => ({
+  profileAccountSelector,
+  (drafts, preferences, account) => ({
     drafts,
     preferences,
+    account,
   }),
 );
 

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -3,6 +3,23 @@ import { getAuthenticatedHttpClient as getHttpClient } from '@edx/frontend-platf
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject, convertKeyNames, snakeCaseObject } from '../utils';
 import { FIELD_LABELS } from './constants';
+import {
+  BIODATA_API_DEFAULT_BASE_PATH,
+  BIODATA_VALIDATE_PATH,
+  getConfiguredBiodataSections,
+  getSectionEndpointConfig,
+  getSectionRepeatableConfigs,
+} from '../biodata/apiConfig';
+import {
+  buildBiodataExtendedProfile,
+  buildSectionExtendedProfile,
+  buildValidationPayload,
+  mapSectionDataToFlatPayload,
+  mapSectionDataToRepeatablePayloads,
+  mergeSectionIntoExtendedProfile,
+  normalizeBiodataErrorForSection,
+} from '../biodata/apiTransforms';
+import { getSectionById } from '../biodata/utils';
 
 ensureConfig(['LMS_BASE_URL'], 'Profile API service');
 
@@ -30,6 +47,136 @@ function processAndThrowError(error, errorDataProcessor) {
   } else {
     throw error;
   }
+}
+
+function normalizeBiodataPath(path) {
+  return path.replace(/^\//, '');
+}
+
+function getBiodataApiBaseUrl() {
+  const { LMS_BASE_URL, BIODATA_API_BASE_URL } = getConfig();
+
+  if (BIODATA_API_BASE_URL) {
+    return BIODATA_API_BASE_URL.replace(/\/$/, '');
+  }
+
+  return `${LMS_BASE_URL}${BIODATA_API_DEFAULT_BASE_PATH}`;
+}
+
+function getBiodataEndpointUrl(path) {
+  return `${getBiodataApiBaseUrl()}/${normalizeBiodataPath(path)}`;
+}
+
+function normalizeBiodataPayload(payload) {
+  return snakeCaseObject(payload);
+}
+
+function isMissingBiodataResponse(error) {
+  const status = error?.response?.status;
+  return status === 404 || status === 403;
+}
+
+async function getFlatBiodataSection(section) {
+  const sectionEndpointConfig = getSectionEndpointConfig(section.id);
+
+  if (!sectionEndpointConfig?.flat?.path) {
+    return null;
+  }
+
+  try {
+    const { data } = await getHttpClient().get(getBiodataEndpointUrl(sectionEndpointConfig.flat.path));
+    return data && typeof data === 'object' ? snakeCaseObject(data) : {};
+  } catch (error) {
+    if (isMissingBiodataResponse(error)) {
+      return {};
+    }
+
+    logError(error);
+    return {};
+  }
+}
+
+async function getRepeatableBiodataSection(section, repeatable, endpoint) {
+  try {
+    const { data } = await getHttpClient().get(getBiodataEndpointUrl(endpoint.path));
+    const rows = Array.isArray(data) ? data : data?.results || [];
+
+    return {
+      storageFieldName: repeatable.storageFieldName,
+      rows: rows.map(row => snakeCaseObject(row)),
+    };
+  } catch (error) {
+    if (!isMissingBiodataResponse(error)) {
+      logError(error);
+    }
+
+    return {
+      storageFieldName: repeatable.storageFieldName,
+      rows: [],
+    };
+  }
+}
+
+async function getBiodataSectionProfile(sectionId) {
+  const section = getSectionById(sectionId);
+
+  if (!section) {
+    return [];
+  }
+
+  const [flatResponse, ...repeatableResponses] = await Promise.all([
+    getFlatBiodataSection(section),
+    ...getSectionRepeatableConfigs(section)
+      .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(section, repeatable, endpoint)),
+  ]);
+
+  const repeatableResponsesByKey = repeatableResponses.reduce((accumulator, { storageFieldName, rows }) => {
+    accumulator[storageFieldName] = rows;
+    return accumulator;
+  }, {});
+
+  return buildSectionExtendedProfile(sectionId, flatResponse || {}, repeatableResponsesByKey);
+}
+
+async function updateRepeatableRows(endpointPath, committedRows, draftRows) {
+  const committedRowMap = committedRows.reduce((accumulator, row) => {
+    if (row.backendId != null) {
+      accumulator[String(row.backendId)] = row;
+    }
+    return accumulator;
+  }, {});
+
+  const draftRowMap = draftRows.reduce((accumulator, row) => {
+    if (row.backendId != null) {
+      accumulator[String(row.backendId)] = row;
+    }
+    return accumulator;
+  }, {});
+
+  const operations = [];
+
+  draftRows.forEach((row) => {
+    const payload = normalizeBiodataPayload(row.values);
+    if (row.backendId != null) {
+      operations.push(getHttpClient().patch(
+        getBiodataEndpointUrl(`${endpointPath}${row.backendId}/`),
+        payload,
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      ));
+    } else {
+      operations.push(getHttpClient().post(getBiodataEndpointUrl(endpointPath), payload));
+    }
+  });
+
+  Object.keys(committedRowMap).forEach((backendId) => {
+    if (!draftRowMap[backendId]) {
+      operations.push(getHttpClient().delete(getBiodataEndpointUrl(`${endpointPath}${backendId}/`)));
+    }
+  });
+
+  await Promise.all(operations);
 }
 
 export async function getAccount(username) {
@@ -164,5 +311,103 @@ export async function getCountryList() {
   } catch (e) {
     logError(e);
     return [];
+  }
+}
+
+export async function getBiodataProfile() {
+  const sections = getConfiguredBiodataSections();
+  const flatResponsesBySection = {};
+  const repeatableResponsesByKey = {};
+
+  await Promise.all(sections.map(async (section) => {
+    const [flatResponse, ...repeatableResponses] = await Promise.all([
+      getFlatBiodataSection(section),
+      ...getSectionRepeatableConfigs(section)
+        .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(section, repeatable, endpoint)),
+    ]);
+
+    if (flatResponse) {
+      flatResponsesBySection[section.id] = flatResponse;
+    }
+
+    repeatableResponses.forEach(({ storageFieldName, rows }) => {
+      repeatableResponsesByKey[storageFieldName] = rows;
+    });
+  }));
+
+  return buildBiodataExtendedProfile(flatResponsesBySection, repeatableResponsesByKey);
+}
+
+export async function validateBiodataSection(sectionId, sectionData) {
+  const section = getSectionById(sectionId);
+
+  if (!section) {
+    return null;
+  }
+
+  const payload = normalizeBiodataPayload(buildValidationPayload(section, sectionData));
+  try {
+    await getHttpClient().post(getBiodataEndpointUrl(BIODATA_VALIDATE_PATH), payload);
+    return null;
+  } catch (error) {
+    throw normalizeBiodataErrorForSection(error, sectionId);
+  }
+}
+
+export async function saveBiodataSection(sectionId, sectionData, committedData, currentExtendedProfile = []) {
+  const section = getSectionById(sectionId);
+  const sectionEndpointConfig = getSectionEndpointConfig(sectionId);
+
+  if (!section || !sectionEndpointConfig) {
+    return { extendedProfile: [] };
+  }
+
+  try {
+    if (sectionEndpointConfig.flat?.path) {
+      const flatPayload = normalizeBiodataPayload(mapSectionDataToFlatPayload(section, sectionData));
+      await getHttpClient().patch(
+        getBiodataEndpointUrl(sectionEndpointConfig.flat.path),
+        flatPayload,
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+    }
+
+    const repeatablePayloads = mapSectionDataToRepeatablePayloads(section, sectionData);
+    const committedRepeatablePayloads = mapSectionDataToRepeatablePayloads(section, committedData || {});
+
+    await Promise.all(repeatablePayloads.map(async (payload) => {
+      if (Object.keys(payload.extraFields).length > 0 && sectionEndpointConfig.flat?.path) {
+        await getHttpClient().patch(
+          getBiodataEndpointUrl(sectionEndpointConfig.flat.path),
+          normalizeBiodataPayload(payload.extraFields),
+          {
+            headers: { 'Content-Type': 'application/json' },
+          },
+        );
+      }
+
+      const committedRepeatable = committedRepeatablePayloads.find(
+        item => item.repeatable.storageFieldName === payload.repeatable.storageFieldName,
+      );
+
+      await updateRepeatableRows(
+        payload.endpoint.path,
+        committedRepeatable?.rows || [],
+        payload.rows,
+      );
+    }));
+
+    const savedSectionProfile = await getBiodataSectionProfile(sectionId);
+    return {
+      extendedProfile: mergeSectionIntoExtendedProfile(
+        sectionId,
+        currentExtendedProfile,
+        savedSectionProfile,
+      ),
+    };
+  } catch (error) {
+    throw normalizeBiodataErrorForSection(error, sectionId);
   }
 }

--- a/src/profile/data/services.test.js
+++ b/src/profile/data/services.test.js
@@ -2,6 +2,7 @@ import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import {
   getAccount,
+  getBiodataProfile,
   patchProfile,
   postProfilePhoto,
   deleteProfilePhoto,
@@ -9,6 +10,8 @@ import {
   patchPreferences,
   getCourseCertificates,
   getCountryList,
+  saveBiodataSection,
+  validateBiodataSection,
 } from './services';
 
 import { FIELD_LABELS } from './constants';
@@ -18,7 +21,9 @@ import { camelCaseObject, snakeCaseObject, convertKeyNames } from '../utils';
 // --- Mocks ---
 jest.mock('@edx/frontend-platform', () => ({
   ensureConfig: jest.fn(),
-  getConfig: jest.fn(() => ({ LMS_BASE_URL: 'http://fake-lms' })),
+  getConfig: jest.fn(() => ({
+    LMS_BASE_URL: 'http://fake-lms',
+  })),
 }));
 
 jest.mock('@edx/frontend-platform/auth', () => ({
@@ -59,6 +64,88 @@ describe('services', () => {
       expect(mockHttpClient.get).toHaveBeenCalledWith(
         'http://fake-lms/api/user/v1/accounts/john',
       );
+    });
+  });
+
+  describe('getBiodataProfile', () => {
+    it('should load configured flat and repeatable biodata endpoints into extendedProfile shape', async () => {
+      mockHttpClient.get.mockImplementation((url) => {
+        if (url.endsWith('/basic-information/')) {
+          return Promise.resolve({
+            data: {
+              full_name: 'John Doe',
+              marital_status: 'single',
+            },
+          });
+        }
+
+        if (url.endsWith('/education/')) {
+          return Promise.resolve({
+            data: { results: [{ id: 10, institute: 'NDU' }] },
+          });
+        }
+
+        if (url.endsWith('/languages/')) {
+          return Promise.resolve({
+            data: [{
+              id: 11,
+              language: 'English',
+              speaking: 'Basic',
+              reading: 'Advanced',
+              writing: 'Native',
+            }],
+          });
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      const result = await getBiodataProfile();
+
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({ fieldName: 'profile_full_name', fieldValue: 'John Doe' }),
+        expect.objectContaining({ fieldName: 'marital_status', fieldValue: 'single' }),
+        expect.objectContaining({
+          fieldName: 'education_records',
+          fieldValue: [expect.objectContaining({ educational_institute: 'NDU', backendId: 10 })],
+        }),
+        expect.objectContaining({
+          fieldName: 'language_proficiencies',
+          fieldValue: [expect.objectContaining({
+            language_name: 'English',
+            speaking_proficiency: 'Basic',
+            reading_proficiency: 'Advanced',
+            writing_proficiency: 'Native',
+            backendId: 11,
+          })],
+        }),
+      ]));
+    });
+
+    it('should return empty biodata state instead of failing when biodata endpoints are missing', async () => {
+      mockHttpClient.get.mockImplementation((url) => {
+        if (url.endsWith('/basic-information/')) {
+          const error = new Error('missing basic information endpoint');
+          error.response = { status: 404 };
+          return Promise.reject(error);
+        }
+
+        if (url.endsWith('/education/')) {
+          const error = new Error('missing education endpoint');
+          error.response = { status: 404 };
+          return Promise.reject(error);
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      const result = await getBiodataProfile();
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toEqual(expect.arrayContaining([
+        expect.objectContaining({ fieldName: 'profile_full_name', fieldValue: '' }),
+        expect.objectContaining({ fieldName: 'education_records', fieldValue: [] }),
+      ]));
     });
   });
 
@@ -169,6 +256,176 @@ describe('services', () => {
       const result = await getCountryList();
       expect(result).toEqual([]);
       expect(logError).toHaveBeenCalled();
+    });
+  });
+
+  describe('validateBiodataSection', () => {
+    it('should post validation payload to the biodata validation endpoint', async () => {
+      mockHttpClient.post.mockResolvedValue({});
+
+      await validateBiodataSection('basicInformation', {
+        profile_full_name: 'John Doe',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/validate\/$/),
+        expect.objectContaining({
+          section: 'basicInformation',
+          flat: expect.objectContaining({
+            full_name: 'John Doe',
+          }),
+        }),
+      );
+    });
+  });
+
+  describe('saveBiodataSection', () => {
+    it('should patch flat biodata sections and return refreshed extendedProfile', async () => {
+      mockHttpClient.patch.mockResolvedValue({});
+      mockHttpClient.get.mockResolvedValue({ data: {} });
+
+      const result = await saveBiodataSection(
+        'basicInformation',
+        { profile_full_name: 'John Doe' },
+        { profile_full_name: '' },
+      );
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/basic-information\/$/),
+        expect.objectContaining({
+          full_name: 'John Doe',
+        }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+        },
+      );
+      expect(result).toHaveProperty('extendedProfile');
+    });
+
+    it('should map backend validation errors to UI field names', async () => {
+      const error = new Error('validation failed');
+      error.response = {
+        data: {
+          cnic: ['Enter a valid CNIC in the format XXXXX-XXXXXXX-X.'],
+        },
+      };
+      mockHttpClient.patch.mockRejectedValue(error);
+
+      await expect(saveBiodataSection(
+        'basicInformation',
+        { identity_card_number: 'bad' },
+        { identity_card_number: '' },
+      )).rejects.toMatchObject({
+        processedData: {
+          fieldErrors: {
+            identity_card_number: {
+              userMessage: 'Enter a valid CNIC in the format XXXXX-XXXXXXX-X.',
+            },
+          },
+        },
+      });
+    });
+
+    it('should map language repeatable row payload fields to backend keys', async () => {
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.get.mockResolvedValue({ data: { results: [] } });
+
+      await saveBiodataSection(
+        'languages',
+        {
+          language_proficiencies: [{
+            rowId: 'row-1',
+            language_name: 'English',
+            speaking_proficiency: 'Native',
+            reading_proficiency: 'Native',
+            writing_proficiency: 'Advanced',
+          }],
+        },
+        {
+          language_proficiencies: [],
+        },
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/$/),
+        expect.objectContaining({
+          language: 'English',
+          speaking: 'Native',
+          reading: 'Native',
+          writing: 'Advanced',
+        }),
+      );
+    });
+
+    it('should map education repeatable row payload fields to backend keys', async () => {
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.get.mockResolvedValue({ data: { results: [] } });
+
+      await saveBiodataSection(
+        'education',
+        {
+          education_records: [{
+            rowId: 'row-1',
+            educational_institute: 'UOS',
+            attended_from: '2005-06-21',
+            attended_to: '2009-09-25',
+            examination: 'Bachelors',
+            year_of_passing: '2009',
+            grade_division: '',
+            subjects_studied: 'computer science',
+          }],
+        },
+        {
+          education_records: [],
+        },
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/education\/$/),
+        expect.objectContaining({
+          institute: 'UOS',
+          attended_from: '2005-06-21',
+          attended_to: '2009-09-25',
+          examination: 'Bachelors',
+          year_of_passing: '2009',
+          grade: '',
+          subjects: 'computer science',
+        }),
+      );
+    });
+
+    it('should map repeatable backend validation errors to UI field names', async () => {
+      const error = new Error('validation failed');
+      error.response = {
+        data: {
+          language: ['This field is required.'],
+        },
+      };
+      mockHttpClient.post.mockRejectedValue(error);
+
+      await expect(saveBiodataSection(
+        'languages',
+        {
+          language_proficiencies: [{
+            rowId: 'row-1',
+            language_name: '',
+            speaking_proficiency: 'Native',
+            reading_proficiency: 'Native',
+            writing_proficiency: 'Advanced',
+          }],
+        },
+        {
+          language_proficiencies: [],
+        },
+      )).rejects.toMatchObject({
+        processedData: {
+          fieldErrors: {
+            language_name: {
+              userMessage: 'This field is required.',
+            },
+          },
+        },
+      });
     });
   });
 });


### PR DESCRIPTION
## Description
This PR adds the biodata form to the Profile page in `frontend-app-profile` and integrates it with the biodata backend APIs.

The implementation introduces a structured biodata experience with section-based navigation, editable biodata sections, repeatable form groups, and backend-connected save/load flows while keeping the experience aligned with the existing profile page patterns.

## What’s included
- Added biodata form UI to the Profile page
- Added left-side section navigation for biodata categories
- Added editable biodata sections using the existing profile page structure
- Added support for flat and repeatable biodata form groups
- Integrated biodata sections with backend APIs
- Added support for loading and saving biodata data from the backend
- Added support for create/update/delete flows for repeatable sections
- Added conditional rendering and behavior for biodata-specific fields
- Added Paragon-aligned checkbox handling and form patterns
- Removed serial number field from the Education section
- Added `N/A` handling for applicable sections
- Added spouse/children field behavior based on marital status

## Biodata sections covered
- Basic Information
- Physical / Medical Information
- Contact Information
- Education
- Achievements
- Languages
- Employment
- Competitive Examinations
- CSS Exam Details
- Government Service Details
- Personal Interests
- Foreign Visits
- Family Information
- Close Relatives in Government Service
- Spouse Information
- Declaration

## Backend integration
This PR integrates the biodata form with the backend endpoints for:
- flat section GET/PATCH flows
- repeatable section GET/POST/PATCH/DELETE flows
- biodata validation flow

## Notes
- This PR includes both biodata form implementation and backend integration in the Profile MFE
- Screenshots are attached for the implemented UI
- The implementation follows the existing frontend-app-profile communication patterns for backend interaction

<img width="3024" height="1630" alt="Screenshot 2026-04-14 at 7 49 49 PM" src="https://github.com/user-attachments/assets/20d78382-07e7-483a-add6-a5ea002f832c" />

<img width="1904" height="921" alt="Screenshot 2026-04-15 at 7 38 18 PM" src="https://github.com/user-attachments/assets/778b1482-d784-46f9-a6dd-084e7d8d5a7e" />

<img width="1904" height="919" alt="Screenshot 2026-04-15 at 7 37 53 PM" src="https://github.com/user-attachments/assets/5351c075-3aa8-4c7c-a865-b4996b68c637" />

