### PR TITLE
feat: Implement required biodata profile completion flow

### DIFF
--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -1,5 +1,5 @@
 import React, {
-  useEffect, useState, useContext, useCallback,
+  useEffect, useState, useContext, useCallback, useRef,
 } from 'react';
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
@@ -23,6 +23,7 @@ import DateJoined from './DateJoined';
 import UserCertificateSummary from './UserCertificateSummary';
 import PageLoading from './PageLoading';
 import Certificates from './Certificates';
+import OutsideHrmsInstructorForm from './forms/outside-hrms/OutsideHrmsInstructorForm';
 
 import { profilePageSelector } from './data/selectors';
 import messages from './ProfilePage.messages';
@@ -32,6 +33,22 @@ import { useIsOnMobileScreen, useIsOnTabletScreen } from './data/hooks';
 import BiodataProfileSections from './biodata/BiodataProfileSections';
 
 ensureConfig(['CREDENTIALS_BASE_URL', 'LMS_BASE_URL', 'ACCOUNT_SETTINGS_URL'], 'ProfilePage');
+
+const IGNORED_LINK_PROTOCOLS = ['mailto:', 'tel:', 'java'.concat('script:')];
+const LOGOUT_PATH_PATTERN = /(^|\/)(logout|signout|sign-out)(\/|$)/i;
+
+function isLogoutNavigation(targetUrl, config = {}) {
+  const configuredLogoutUrl = config.LOGOUT_URL;
+
+  if (configuredLogoutUrl) {
+    const logoutUrl = new URL(configuredLogoutUrl, window.location.href);
+    if (targetUrl.origin === logoutUrl.origin && targetUrl.pathname === logoutUrl.pathname) {
+      return true;
+    }
+  }
+
+  return LOGOUT_PATH_PATTERN.test(targetUrl.pathname);
+}
 
 const ProfilePage = ({ params }) => {
   const dispatch = useDispatch();
@@ -46,10 +63,14 @@ const ProfilePage = ({ params }) => {
     photoUploadError,
     saveState,
     username,
+    profileCompletionStatus,
   } = useSelector(profilePageSelector);
 
   const navigate = useNavigate();
   const [viewMyRecordsUrl, setViewMyRecordsUrl] = useState(null);
+  const [completionOverride, setCompletionOverride] = useState(false);
+  const [navigationBlocked, setNavigationBlocked] = useState(false);
+  const allowRequiredProfileLogoutRef = useRef(false);
   const isMobileView = useIsOnMobileScreen();
   const isTabletView = useIsOnTabletScreen();
 
@@ -82,6 +103,77 @@ const ProfilePage = ({ params }) => {
   }, [dispatch, authenticatedUserName]);
 
   const isAuthenticatedUserProfile = () => params.username === authenticatedUserName;
+  const isOutsideHrmsLearner = isAuthenticatedUserProfile()
+    && !context.authenticatedUser.administrator;
+  const hasCompletedRequiredProfile = completionOverride
+    || Boolean(profileCompletionStatus?.complete);
+  const shouldBlockNavigation = isAuthenticatedUserProfile()
+    && Boolean(profileCompletionStatus?.required)
+    && !hasCompletedRequiredProfile;
+
+  useEffect(() => {
+    if (!shouldBlockNavigation) {
+      return undefined;
+    }
+
+    const handleClick = (event) => {
+      const link = event.target.closest?.('a[href]');
+      if (!link) {
+        return;
+      }
+
+      const href = link.getAttribute('href');
+      if (!href) {
+        return;
+      }
+
+      const normalizedHref = href.toLowerCase();
+      if (href.startsWith('#') || IGNORED_LINK_PROTOCOLS.some(protocol => normalizedHref.startsWith(protocol))) {
+        return;
+      }
+
+      const targetUrl = new URL(href, window.location.href);
+      if (isLogoutNavigation(targetUrl, context.config)) {
+        allowRequiredProfileLogoutRef.current = true;
+        return;
+      }
+
+      const allowedProfileUrl = new URL(
+        profileCompletionStatus?.profileUrl || window.location.href,
+        window.location.href,
+      );
+      const isCurrentProfileRoute = targetUrl.origin === window.location.origin
+        && targetUrl.pathname === window.location.pathname;
+      const isRequiredProfileRoute = targetUrl.href === allowedProfileUrl.href
+        || targetUrl.pathname === allowedProfileUrl.pathname;
+
+      if (!isCurrentProfileRoute && !isRequiredProfileRoute) {
+        event.preventDefault();
+        event.stopPropagation();
+        setNavigationBlocked(true);
+      }
+    };
+
+    const handleBeforeUnload = (event) => {
+      if (allowRequiredProfileLogoutRef.current) {
+        return undefined;
+      }
+
+      event.preventDefault();
+      // Browser beforeunload prompts still require assigning returnValue.
+      // eslint-disable-next-line no-param-reassign
+      event.returnValue = '';
+      return '';
+    };
+
+    document.addEventListener('click', handleClick, true);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      document.removeEventListener('click', handleClick, true);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, [context.config, profileCompletionStatus, shouldBlockNavigation]);
 
   const isBlockVisible = (blockInfo) => isAuthenticatedUserProfile()
       || (!isAuthenticatedUserProfile() && Boolean(blockInfo));
@@ -200,6 +292,13 @@ const ProfilePage = ({ params }) => {
               </div>
             </div>
           </div>
+          {navigationBlocked && (
+            <div className={classNames(isMobileView ? 'px-3 pt-4' : 'px-120px pt-4')}>
+              <Alert variant="warning" dismissible onClose={() => setNavigationBlocked(false)} show>
+                Complete and save your required profile form before opening another page.
+              </Alert>
+            </div>
+          )}
           <div
             className={classNames([
               'col d-inline-flex h-100 w-100 align-items-start justify-content-start g-3rem',
@@ -207,7 +306,15 @@ const ProfilePage = ({ params }) => {
             ])}
           >
             <div className="w-100 p-0">
-              <BiodataProfileSections />
+              {isOutsideHrmsLearner ? (
+                <OutsideHrmsInstructorForm
+                  username={authenticatedUserName}
+                  onComplete={() => {
+                    setCompletionOverride(true);
+                    setNavigationBlocked(false);
+                  }}
+                />
+              ) : <BiodataProfileSections />}
             </div>
           </div>
           <div

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -96,64 +96,7 @@ exports[`<ProfilePage /> Renders correctly in various states successfully redire
     >
       <div
         class="w-100 p-0"
-      >
-        <div
-          class="col justify-content-start align-items-start p-0"
-        >
-          <div
-            class="col align-self-stretch height-42px justify-content-start align-items-start p-0"
-          >
-            <p
-              class="font-weight-bold text-primary-500 m-0 h2"
-            >
-              Profile information
-            </p>
-          </div>
-        </div>
-        <div
-          class="row m-0 px-0 w-100 d-inline-flex align-items-start justify-content-start pt-5.5"
-        >
-          <div
-            class="col p-0 col-6"
-          >
-            <div
-              class="m-0"
-            >
-              <div
-                class="row m-0 pb-1.5 align-items-center"
-              >
-                <p
-                  class="h5 font-weight-bold m-0"
-                  data-hj-suppress="true"
-                >
-                  Username
-                </p>
-                <svg
-                  class="m-0 info-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="edit-section-header text-gray-700"
-              >
-                staffTest
-              </h4>
-            </div>
-          </div>
-          <div
-            class="col m-0 pr-0 pl-40px col-6"
-          />
-        </div>
-      </div>
+      />
     </div>
     <div
       class="col container-fluid d-inline-flex bg-color-grey-FBFAF9 h-100 w-100 align-items-start justify-content-start g-3rem px-120px py-6"
@@ -214,11 +157,6 @@ exports[`<ProfilePage /> Renders correctly in various states viewing other profi
               >
                 verified
               </p>
-              <p
-                class="row pt-2 text-gray-800 font-weight-normal m-0 p"
-              >
-                Verified User
-              </p>
               <div
                 class="row pt-2 m-0 g-1rem"
               >
@@ -253,279 +191,720 @@ exports[`<ProfilePage /> Renders correctly in various states viewing other profi
         class="w-100 p-0"
       >
         <div
-          class="col justify-content-start align-items-start p-0"
+          class="row"
         >
           <div
-            class="col align-self-stretch height-42px justify-content-start align-items-start p-0"
-          >
-            <p
-              class="font-weight-bold text-primary-500 m-0 h2"
-            >
-              Profile information
-            </p>
-          </div>
-        </div>
-        <div
-          class="row m-0 px-0 w-100 d-inline-flex align-items-start justify-content-start pt-5.5"
-        >
-          <div
-            class="col p-0 col-6"
+            class="col-lg-3 mb-4 mb-lg-0"
           >
             <div
-              class="m-0"
+              class="position-lg-sticky pgn__card pgn__card-light card"
+              style="top: 0px;"
+              tabindex="-1"
             >
               <div
-                class="row m-0 pb-1.5 align-items-center"
-              >
-                <p
-                  class="h5 font-weight-bold m-0"
-                  data-hj-suppress="true"
-                >
-                  Username
-                </p>
-                <svg
-                  class="m-0 info-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="edit-section-header text-gray-700"
-              >
-                verified
-              </h4>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
+                class="pgn__card-section"
               >
                 <div
-                  class="row m-0 pb-1.5 align-items-center"
-                >
-                  <p
-                    class="h5 font-weight-bold m-0"
-                    data-hj-suppress="true"
-                  >
-                    Full name
-                  </p>
-                  <svg
-                    class="m-0 info-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                  class="flex-column nav nav-pills"
                 >
                   <div
-                    class="m-0 p-0 col-auto"
+                    class="nav-item"
                   >
-                    <h4
-                      class="edit-section-header text-gray-700"
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link active"
+                      data-biodata-nav="basicInformation"
+                      href="#"
+                      role="button"
                     >
-                      Verified User
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  />
-                </div>
-                <div
-                  class="row m-0 p-0"
-                />
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Country
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      United States of America
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  />
-                </div>
-                <div
-                  class="row m-0 p-0"
-                />
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Primary language spoken
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      English
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  />
-                </div>
-                <div
-                  class="row m-0 p-0"
-                />
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Education
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Other education
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  />
-                </div>
-                <div
-                  class="row m-0 p-0"
-                />
-              </div>
-            </div>
-          </div>
-          <div
-            class="col m-0 pr-0 pl-40px col-6"
-          >
-            <div
-              class="pgn-transition-replace-group position-relative pt-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Bio
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      About me
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  />
-                </div>
-                <div
-                  class="row m-0 p-0"
-                />
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative p-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <div>
-                  <div>
-                    <div
-                      class="pt-40px"
-                    >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
                       >
-                        X
-                      </p>
-                      <div
-                        class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                      >
-                        <div
-                          class="m-0 p-0 col-auto"
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-primary text-white"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
                         >
-                          <h4
-                            class="edit-section-header text-gray-700"
-                          >
-                            https://twitter.com/user
-                          </h4>
-                        </div>
-                        <div
-                          class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                          1
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
                         />
-                      </div>
-                      <div
-                        class="row m-0 p-0"
-                      />
-                    </div>
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Basic Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Current
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="physicalMedicalInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          2
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Physical / Medical Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="contactInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          3
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Contact Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="education"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          4
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Education
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="achievements"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          5
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Achievements
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="languages"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          6
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Languages
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="employment"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          7
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Employment
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="competitiveExaminations"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          8
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Competitive Examinations
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="cssExamDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          9
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          CSS Exam Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="governmentServiceDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          10
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Government Service Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="personalInterests"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          11
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Personal Interests
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="foreignVisits"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          12
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Foreign Visits
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="familyInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          13
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Family Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="closeRelativesInGovernmentService"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          14
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Close Relatives in Government Service
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="declaration"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          15
+                        </span>
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Declaration
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="col-lg-9"
+          >
+            <div
+              class="shadow-sm pgn__card pgn__card-light card"
+              id="biodata-section-basicInformation"
+              tabindex="-1"
+            >
+              <div
+                class="pgn__card-section"
+              >
+                <div
+                  class="mb-3"
+                >
+                  <div
+                    class="font-weight-bold text-gray-900 h5 mb-1"
+                  >
+                    Basic Information
+                  </div>
+                  <div
+                    class="small text-muted"
+                  >
+                    Core personal biodata details.
                   </div>
                 </div>
               </div>
@@ -635,11 +1014,6 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
               >
                 staff
               </p>
-              <p
-                class="row pt-2 text-gray-800 font-weight-normal m-0 p"
-              >
-                Lemon Seltzer
-              </p>
               <div
                 class="row pt-2 m-0 g-1rem"
               >
@@ -693,667 +1067,1048 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
         class="w-100 p-0"
       >
         <div
-          class="col justify-content-start align-items-start p-0"
+          class="row"
         >
           <div
-            class="col align-self-stretch height-42px justify-content-start align-items-start p-0"
+            class="col-lg-3 mb-4 mb-lg-0"
           >
-            <p
-              class="font-weight-bold text-primary-500 m-0 h2"
+            <div
+              class="position-lg-sticky pgn__card pgn__card-light card"
+              style="top: 0px;"
+              tabindex="-1"
             >
-              Profile information
-            </p>
+              <div
+                class="pgn__card-section"
+              >
+                <div
+                  class="flex-column nav nav-pills"
+                >
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link active"
+                      data-biodata-nav="basicInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-primary text-white"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          1
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Basic Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Current
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="physicalMedicalInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          2
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Physical / Medical Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="contactInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          3
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Contact Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="education"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          4
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Education
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="achievements"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          5
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Achievements
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="languages"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          6
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Languages
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="employment"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          7
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Employment
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="competitiveExaminations"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          8
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Competitive Examinations
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="cssExamDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          9
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          CSS Exam Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="governmentServiceDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          10
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Government Service Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="personalInterests"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          11
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Personal Interests
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="foreignVisits"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          12
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Foreign Visits
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="familyInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          13
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Family Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="closeRelativesInGovernmentService"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          14
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Close Relatives in Government Service
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="declaration"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          15
+                        </span>
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Declaration
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-        <div
-          class="row m-0 px-0 w-100 d-inline-flex align-items-start justify-content-start pt-5.5"
-        >
           <div
-            class="col p-0 col-6"
+            class="col-lg-9"
           >
             <div
-              class="m-0"
+              class="shadow-sm pgn__card pgn__card-light card"
+              id="biodata-section-basicInformation"
+              tabindex="-1"
             >
               <div
-                class="row m-0 pb-1.5 align-items-center"
-              >
-                <p
-                  class="h5 font-weight-bold m-0"
-                  data-hj-suppress="true"
-                >
-                  Username
-                </p>
-                <svg
-                  class="m-0 info-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="edit-section-header text-gray-700"
-              >
-                staff
-              </h4>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
+                class="pgn__card-section"
               >
                 <div
-                  class="row m-0 pb-1.5 align-items-center"
-                >
-                  <p
-                    class="h5 font-weight-bold m-0"
-                    data-hj-suppress="true"
-                  >
-                    Full name
-                  </p>
-                  <svg
-                    class="m-0 info-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                  class="mb-3"
                 >
                   <div
-                    class="m-0 p-0 col-auto"
+                    class="font-weight-bold text-gray-900 h5 mb-1"
                   >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Lemon Seltzer
-                    </h4>
+                    Basic Information
                   </div>
                   <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                    class="small text-muted"
                   >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
+                    Core personal biodata details.
                   </div>
                 </div>
                 <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye-slash "
-                        data-icon="eye-slash"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 640 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm9.4 130.3C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5l-41.9-33zM192 256c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Just me
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Country
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                  class="pgn-transition-replace-group position-relative pt-0"
                 >
                   <div
-                    class="m-0 p-0 col-auto"
+                    style="padding: 0.1px 0px;"
                   >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Montenegro
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Primary language spoken
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Yoruba
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Education
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Elementary/primary school
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye-slash "
-                        data-icon="eye-slash"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 640 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm9.4 130.3C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5l-41.9-33zM192 256c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Just me
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="col m-0 pr-0 pl-40px col-6"
-          >
-            <div
-              class="pgn-transition-replace-group position-relative pt-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Bio
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      This is my bio
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative p-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <div>
-                  <div>
                     <div
-                      class="pt-40px"
+                      aria-labelledby="basicInformation-label"
+                      role="dialog"
                     >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        X
-                      </p>
-                      <div
-                        class="w-100 overflowWrap-breakWord"
-                      >
+                      <form>
                         <div
-                          class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                          class="row"
                         >
                           <div
-                            class="m-0 p-0 col-auto"
+                            class="pgn__form-group col-md-6 mb-3"
                           >
-                            <h4
-                              class="edit-section-header text-gray-700"
+                            <label
+                              class="pgn__form-label"
+                              for="form-field1"
                             >
-                              https://www.twitter.com/ALOHA
-                            </h4>
+                              Title
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <select
+                                class="form-control"
+                                id="form-field1"
+                              >
+                                <option
+                                  value=""
+                                >
+                                  Select title
+                                </option>
+                                <option
+                                  value="mr"
+                                >
+                                  Mr
+                                </option>
+                                <option
+                                  value="mrs"
+                                >
+                                  Mrs
+                                </option>
+                                <option
+                                  value="ms"
+                                >
+                                  Ms
+                                </option>
+                                <option
+                                  value="miss"
+                                >
+                                  Miss
+                                </option>
+                              </select>
+                            </div>
                           </div>
                           <div
-                            class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                            class="pgn__form-group col-md-6 mb-3"
                           >
-                            <button
-                              class="p-1.5 btn btn-link btn-sm"
-                              type="button"
+                            <label
+                              class="pgn__form-label"
+                              for="form-field2"
                             >
-                              <svg
-                                class="text-gray-700"
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
+                              Full Name
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field2"
+                                placeholder="Enter full name"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field3"
+                            >
+                              Preferred / calling name
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field3"
+                                placeholder="Enter preferred name"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field4"
+                            >
+                              Identity Card Number
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field4"
+                                placeholder="Enter identity card number"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field5"
+                            >
+                              Date of Birth
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field5"
+                                type="date"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field6"
+                            >
+                              Place of Birth
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field6"
+                                placeholder="Enter place of birth"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field7"
+                            >
+                              District of Domicile
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field7"
+                                placeholder="Enter district of domicile"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field8"
+                            >
+                              Religion
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field8"
+                                placeholder="Enter religion"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field9"
+                            >
+                              Marital Status
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <select
+                                class="form-control"
+                                id="form-field9"
                               >
-                                <path
-                                  d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            </button>
+                                <option
+                                  value=""
+                                >
+                                  Select marital status
+                                </option>
+                                <option
+                                  value="single"
+                                >
+                                  Single
+                                </option>
+                                <option
+                                  value="married"
+                                >
+                                  Married
+                                </option>
+                                <option
+                                  value="widowed"
+                                >
+                                  Widowed
+                                </option>
+                                <option
+                                  value="divorced"
+                                >
+                                  Divorced
+                                </option>
+                              </select>
+                            </div>
                           </div>
                         </div>
                         <div
-                          class="row m-0 p-0"
+                          class="border rounded p-3 mb-3 bg-light-200"
                         >
                           <p
-                            class="mb-0"
+                            class="h6 font-weight-bold mb-2"
                           >
-                            <span
-                              class="ml-auto small text-muted"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="svg-inline--fa fa-eye "
-                                data-icon="eye"
-                                data-prefix="far"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 576 512"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                               
-                              Everyone on localhost
-                            </span>
+                            CNIC Attachment
                           </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="pt-40px"
-                    >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        Facebook
-                      </p>
-                      <div
-                        class="w-100 overflowWrap-breakWord"
-                      >
-                        <div
-                          class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                        >
                           <div
-                            class="m-0 p-0 col-auto"
-                          >
-                            <h4
-                              class="edit-section-header text-gray-700"
-                            >
-                              https://www.facebook.com/aloha
-                            </h4>
-                          </div>
-                          <div
-                            class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                            class="d-flex flex-wrap align-items-center"
                           >
                             <button
-                              class="p-1.5 btn btn-link btn-sm"
+                              class="btn btn-outline-primary btn-sm"
                               type="button"
                             >
-                              <svg
-                                class="text-gray-700"
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
+                              Upload cnic attachment
                             </button>
                           </div>
+                          <input
+                            accept=".jpg,.jpeg,.png,.webp,.pdf"
+                            class="d-none"
+                            id="basicInformation-cnic_attachment"
+                            type="file"
+                          />
                         </div>
                         <div
-                          class="row m-0 p-0"
+                          class="border rounded p-3 mb-3 bg-light-200"
                         >
                           <p
-                            class="mb-0"
+                            class="h6 font-weight-bold mb-2"
                           >
-                            <span
-                              class="ml-auto small text-muted"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="svg-inline--fa fa-eye "
-                                data-icon="eye"
-                                data-prefix="far"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 576 512"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                               
-                              Everyone on localhost
-                            </span>
+                            Domicile Attachment
                           </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="pt-40px"
-                    >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        LinkedIn
-                      </p>
-                      <div
-                        class="p-0 m-0"
-                      >
-                        <button
-                          class="p-0 text-left btn btn-link lh-36px"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="svg-inline--fa fa-plus fa-xs mr-1"
-                            data-icon="plus"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 448 512"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="d-flex flex-wrap align-items-center"
                           >
-                            <path
-                              d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 144L48 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l144 0 0 144c0 17.7 14.3 32 32 32s32-14.3 32-32l0-144 144 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-144 0 0-144z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                          Add 
-                          LinkedIn
-                        </button>
-                      </div>
+                            <button
+                              class="btn btn-outline-primary btn-sm"
+                              type="button"
+                            >
+                              Upload domicile attachment
+                            </button>
+                          </div>
+                          <input
+                            accept=".jpg,.jpeg,.png,.webp,.pdf"
+                            class="d-none"
+                            id="basicInformation-domicile_attachment"
+                            type="file"
+                          />
+                        </div>
+                        <div
+                          class="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                        >
+                          <div
+                            class="row form-group flex-shrink-0 flex-grow-1 m-0 p-0"
+                          >
+                            <div
+                              class="p-0 m-0"
+                            >
+                              <button
+                                aria-disabled="false"
+                                aria-live="assertive"
+                                class="pgn__stateful-btn pgn__stateful-btn-state-null btn btn-primary"
+                                type="submit"
+                              >
+                                <span
+                                  class="d-flex align-items-center justify-content-center"
+                                >
+                                  <span>
+                                    Save and Next
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </form>
                     </div>
                   </div>
                 </div>
@@ -1403,7 +2158,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
               >
                 <div
                   class="certificate-type-illustration"
-                  style="background-image: url(icon/mock/path);"
+                  style="background-image: url("icon/mock/path");"
                 />
                 <div
                   class="d-flex flex-column position-relative p-0 width-314px"
@@ -1560,11 +2315,6 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
               >
                 staff
               </p>
-              <p
-                class="row pt-2 text-gray-800 font-weight-normal m-0 p"
-              >
-                Lemon Seltzer
-              </p>
               <div
                 class="row pt-2 m-0 g-1rem"
               >
@@ -1609,667 +2359,1048 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
         class="w-100 p-0"
       >
         <div
-          class="col justify-content-start align-items-start p-0"
+          class="row"
         >
           <div
-            class="col align-self-stretch height-42px justify-content-start align-items-start p-0"
+            class="col-lg-3 mb-4 mb-lg-0"
           >
-            <p
-              class="font-weight-bold text-primary-500 m-0 h2"
+            <div
+              class="position-lg-sticky pgn__card pgn__card-light card"
+              style="top: 0px;"
+              tabindex="-1"
             >
-              Profile information
-            </p>
+              <div
+                class="pgn__card-section"
+              >
+                <div
+                  class="flex-column nav nav-pills"
+                >
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link active"
+                      data-biodata-nav="basicInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-primary text-white"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          1
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Basic Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Current
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="physicalMedicalInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          2
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Physical / Medical Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="contactInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          3
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Contact Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="education"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          4
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Education
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="achievements"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          5
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Achievements
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="languages"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          6
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Languages
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="employment"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          7
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Employment
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="competitiveExaminations"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          8
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Competitive Examinations
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="cssExamDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          9
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          CSS Exam Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="governmentServiceDetails"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          10
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Government Service Details
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="personalInterests"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          11
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Personal Interests
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="foreignVisits"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          12
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Foreign Visits
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="familyInformation"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          13
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Family Information
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="closeRelativesInGovernmentService"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          14
+                        </span>
+                        <span
+                          class="border-left flex-grow-1 mt-1 mb-n2 border-light-500"
+                          style="min-height: 1.25rem;"
+                        />
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Close Relatives in Government Service
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                  <div
+                    class="nav-item"
+                  >
+                    <a
+                      class="mb-2 d-flex align-items-stretch text-left position-relative nav-link"
+                      data-biodata-nav="declaration"
+                      href="#"
+                      role="button"
+                    >
+                      <span
+                        aria-hidden="true"
+                        class="d-flex flex-column align-items-center flex-shrink-0 mr-2"
+                      >
+                        <span
+                          class="d-inline-flex align-items-center justify-content-center rounded-circle flex-shrink-0 bg-light-400 text-gray-700"
+                          style="width: 1.75rem; height: 1.75rem; z-index: 1;"
+                        >
+                          15
+                        </span>
+                      </span>
+                      <span
+                        class="pb-2"
+                      >
+                        <span
+                          class="font-weight-bold d-block"
+                        >
+                          Declaration
+                        </span>
+                        <span
+                          class="small d-block text-muted"
+                        >
+                          Not started
+                        </span>
+                        <span
+                          class="small text-muted d-block"
+                        >
+                          No information added
+                        </span>
+                      </span>
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
-        </div>
-        <div
-          class="row m-0 px-0 w-100 d-inline-flex align-items-start justify-content-start pt-5.5"
-        >
           <div
-            class="col p-0 col-6"
+            class="col-lg-9"
           >
             <div
-              class="m-0"
+              class="shadow-sm pgn__card pgn__card-light card"
+              id="biodata-section-basicInformation"
+              tabindex="-1"
             >
               <div
-                class="row m-0 pb-1.5 align-items-center"
-              >
-                <p
-                  class="h5 font-weight-bold m-0"
-                  data-hj-suppress="true"
-                >
-                  Username
-                </p>
-                <svg
-                  class="m-0 info-icon"
-                  fill="none"
-                  height="24"
-                  viewBox="0 0 24 24"
-                  width="24"
-                  xmlns="http://www.w3.org/2000/svg"
-                >
-                  <path
-                    d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                    fill="currentColor"
-                  />
-                </svg>
-              </div>
-              <h4
-                class="edit-section-header text-gray-700"
-              >
-                staff
-              </h4>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
+                class="pgn__card-section"
               >
                 <div
-                  class="row m-0 pb-1.5 align-items-center"
-                >
-                  <p
-                    class="h5 font-weight-bold m-0"
-                    data-hj-suppress="true"
-                  >
-                    Full name
-                  </p>
-                  <svg
-                    class="m-0 info-icon"
-                    fill="none"
-                    height="24"
-                    viewBox="0 0 24 24"
-                    width="24"
-                    xmlns="http://www.w3.org/2000/svg"
-                  >
-                    <path
-                      d="M11 7h2v2h-2V7Zm0 4h2v6h-2v-6Zm1-9C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2Zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8Z"
-                      fill="currentColor"
-                    />
-                  </svg>
-                </div>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                  class="mb-3"
                 >
                   <div
-                    class="m-0 p-0 col-auto"
+                    class="font-weight-bold text-gray-900 h5 mb-1"
                   >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Lemon Seltzer
-                    </h4>
+                    Basic Information
                   </div>
                   <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                    class="small text-muted"
                   >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
+                    Core personal biodata details.
                   </div>
                 </div>
                 <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye-slash "
-                        data-icon="eye-slash"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 640 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm9.4 130.3C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5l-41.9-33zM192 256c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Just me
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Country
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                  class="pgn-transition-replace-group position-relative pt-0"
                 >
                   <div
-                    class="m-0 p-0 col-auto"
+                    style="padding: 0.1px 0px;"
                   >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Montenegro
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Primary language spoken
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Yoruba
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative pt-40px"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Education
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      Elementary/primary school
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye-slash "
-                        data-icon="eye-slash"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 640 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M38.8 5.1C28.4-3.1 13.3-1.2 5.1 9.2S-1.2 34.7 9.2 42.9l592 464c10.4 8.2 25.5 6.3 33.7-4.1s6.3-25.5-4.1-33.7L525.6 386.7c39.6-40.6 66.4-86.1 79.9-118.4c3.3-7.9 3.3-16.7 0-24.6c-14.9-35.7-46.2-87.7-93-131.1C465.5 68.8 400.8 32 320 32c-68.2 0-125 26.3-169.3 60.8L38.8 5.1zm151 118.3C226 97.7 269.5 80 320 80c65.2 0 118.8 29.6 159.9 67.7C518.4 183.5 545 226 558.6 256c-12.6 28-36.6 66.8-70.9 100.9l-53.8-42.2c9.1-17.6 14.2-37.5 14.2-58.7c0-70.7-57.3-128-128-128c-32.2 0-61.7 11.9-84.2 31.5l-46.1-36.1zM394.9 284.2l-81.5-63.9c4.2-8.5 6.6-18.2 6.6-28.3c0-5.5-.7-10.9-2-16c.7 0 1.3 0 2 0c44.2 0 80 35.8 80 80c0 9.9-1.8 19.4-5.1 28.2zm9.4 130.3C378.8 425.4 350.7 432 320 432c-65.2 0-118.8-29.6-159.9-67.7C121.6 328.5 95 286 81.4 256c8.3-18.4 21.5-41.5 39.4-64.8L83.1 161.5C60.3 191.2 44 220.8 34.5 243.7c-3.3 7.9-3.3 16.7 0 24.6c14.9 35.7 46.2 87.7 93 131.1C174.5 443.2 239.2 480 320 480c47.8 0 89.9-12.9 126.2-32.5l-41.9-33zM192 256c0 70.7 57.3 128 128 128c13.3 0 26.1-2 38.2-5.8L302 334c-23.5-5.4-43.1-21.2-53.7-42.3l-56.1-44.2c-.2 2.8-.3 5.6-.3 8.5z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Just me
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-          <div
-            class="col m-0 pr-0 pl-40px col-6"
-          >
-            <div
-              class="pgn-transition-replace-group position-relative pt-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <p
-                  class="h5 font-weight-bold m-0 pb-1.5"
-                  data-hj-suppress="true"
-                >
-                  Bio
-                </p>
-                <div
-                  class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                >
-                  <div
-                    class="m-0 p-0 col-auto"
-                  >
-                    <h4
-                      class="edit-section-header text-gray-700"
-                    >
-                      This is my bio
-                    </h4>
-                  </div>
-                  <div
-                    class="col-auto m-0 p-0 d-flex align-items-center col-auto"
-                  >
-                    <button
-                      class="p-1.5 btn btn-link btn-sm"
-                      type="button"
-                    >
-                      <svg
-                        class="text-gray-700"
-                        fill="none"
-                        height="24"
-                        viewBox="0 0 24 24"
-                        width="24"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                </div>
-                <div
-                  class="row m-0 p-0"
-                >
-                  <p
-                    class="mb-0"
-                  >
-                    <span
-                      class="ml-auto small text-muted"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="svg-inline--fa fa-eye "
-                        data-icon="eye"
-                        data-prefix="far"
-                        focusable="false"
-                        role="img"
-                        viewBox="0 0 576 512"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                          fill="currentColor"
-                        />
-                      </svg>
-                       
-                      Everyone on localhost
-                    </span>
-                  </p>
-                </div>
-              </div>
-            </div>
-            <div
-              class="pgn-transition-replace-group position-relative p-0"
-            >
-              <div
-                style="padding: .1px 0px;"
-              >
-                <div>
-                  <div>
                     <div
-                      class="pt-40px"
+                      aria-labelledby="basicInformation-label"
+                      role="dialog"
                     >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        X
-                      </p>
-                      <div
-                        class="w-100 overflowWrap-breakWord"
-                      >
+                      <form>
                         <div
-                          class="row m-0 p-0 d-flex flex-nowrap align-items-center"
+                          class="row"
                         >
                           <div
-                            class="m-0 p-0 col-auto"
+                            class="pgn__form-group col-md-6 mb-3"
                           >
-                            <h4
-                              class="edit-section-header text-gray-700"
+                            <label
+                              class="pgn__form-label"
+                              for="form-field19"
                             >
-                              https://www.twitter.com/ALOHA
-                            </h4>
+                              Title
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <select
+                                class="form-control"
+                                id="form-field19"
+                              >
+                                <option
+                                  value=""
+                                >
+                                  Select title
+                                </option>
+                                <option
+                                  value="mr"
+                                >
+                                  Mr
+                                </option>
+                                <option
+                                  value="mrs"
+                                >
+                                  Mrs
+                                </option>
+                                <option
+                                  value="ms"
+                                >
+                                  Ms
+                                </option>
+                                <option
+                                  value="miss"
+                                >
+                                  Miss
+                                </option>
+                              </select>
+                            </div>
                           </div>
                           <div
-                            class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                            class="pgn__form-group col-md-6 mb-3"
                           >
-                            <button
-                              class="p-1.5 btn btn-link btn-sm"
-                              type="button"
+                            <label
+                              class="pgn__form-label"
+                              for="form-field20"
                             >
-                              <svg
-                                class="text-gray-700"
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
+                              Full Name
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field20"
+                                placeholder="Enter full name"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field21"
+                            >
+                              Preferred / calling name
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field21"
+                                placeholder="Enter preferred name"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field22"
+                            >
+                              Identity Card Number
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field22"
+                                placeholder="Enter identity card number"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field23"
+                            >
+                              Date of Birth
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field23"
+                                type="date"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field24"
+                            >
+                              Place of Birth
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field24"
+                                placeholder="Enter place of birth"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field25"
+                            >
+                              District of Domicile
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field25"
+                                placeholder="Enter district of domicile"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field26"
+                            >
+                              Religion
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <input
+                                class="form-control"
+                                id="form-field26"
+                                placeholder="Enter religion"
+                                type="text"
+                                value=""
+                              />
+                            </div>
+                          </div>
+                          <div
+                            class="pgn__form-group col-md-6 mb-3"
+                          >
+                            <label
+                              class="pgn__form-label"
+                              for="form-field27"
+                            >
+                              Marital Status
+                            </label>
+                            <div
+                              class="pgn__form-control-decorator-group"
+                            >
+                              <select
+                                class="form-control"
+                                id="form-field27"
                               >
-                                <path
-                                  d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                            </button>
+                                <option
+                                  value=""
+                                >
+                                  Select marital status
+                                </option>
+                                <option
+                                  value="single"
+                                >
+                                  Single
+                                </option>
+                                <option
+                                  value="married"
+                                >
+                                  Married
+                                </option>
+                                <option
+                                  value="widowed"
+                                >
+                                  Widowed
+                                </option>
+                                <option
+                                  value="divorced"
+                                >
+                                  Divorced
+                                </option>
+                              </select>
+                            </div>
                           </div>
                         </div>
                         <div
-                          class="row m-0 p-0"
+                          class="border rounded p-3 mb-3 bg-light-200"
                         >
                           <p
-                            class="mb-0"
+                            class="h6 font-weight-bold mb-2"
                           >
-                            <span
-                              class="ml-auto small text-muted"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="svg-inline--fa fa-eye "
-                                data-icon="eye"
-                                data-prefix="far"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 576 512"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                               
-                              Everyone on localhost
-                            </span>
+                            CNIC Attachment
                           </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="pt-40px"
-                    >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        Facebook
-                      </p>
-                      <div
-                        class="w-100 overflowWrap-breakWord"
-                      >
-                        <div
-                          class="row m-0 p-0 d-flex flex-nowrap align-items-center"
-                        >
                           <div
-                            class="m-0 p-0 col-auto"
-                          >
-                            <h4
-                              class="edit-section-header text-gray-700"
-                            >
-                              https://www.facebook.com/aloha
-                            </h4>
-                          </div>
-                          <div
-                            class="col-auto m-0 p-0 d-flex align-items-center col-auto"
+                            class="d-flex flex-wrap align-items-center"
                           >
                             <button
-                              class="p-1.5 btn btn-link btn-sm"
+                              class="btn btn-outline-primary btn-sm"
                               type="button"
                             >
-                              <svg
-                                class="text-gray-700"
-                                fill="none"
-                                height="24"
-                                viewBox="0 0 24 24"
-                                width="24"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="m14.06 9.02.92.92L5.92 19H5v-.92l9.06-9.06ZM17.66 3c-.25 0-.51.1-.7.29l-1.83 1.83 3.75 3.75 1.83-1.83a.996.996 0 0 0 0-1.41l-2.34-2.34c-.2-.2-.45-.29-.71-.29Zm-3.6 3.19L3 17.25V21h3.75L17.81 9.94l-3.75-3.75Z"
-                                  fill="currentColor"
-                                />
-                              </svg>
+                              Upload cnic attachment
                             </button>
                           </div>
+                          <input
+                            accept=".jpg,.jpeg,.png,.webp,.pdf"
+                            class="d-none"
+                            id="basicInformation-cnic_attachment"
+                            type="file"
+                          />
                         </div>
                         <div
-                          class="row m-0 p-0"
+                          class="border rounded p-3 mb-3 bg-light-200"
                         >
                           <p
-                            class="mb-0"
+                            class="h6 font-weight-bold mb-2"
                           >
-                            <span
-                              class="ml-auto small text-muted"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="svg-inline--fa fa-eye "
-                                data-icon="eye"
-                                data-prefix="far"
-                                focusable="false"
-                                role="img"
-                                viewBox="0 0 576 512"
-                                xmlns="http://www.w3.org/2000/svg"
-                              >
-                                <path
-                                  d="M288 80c-65.2 0-118.8 29.6-159.9 67.7C89.6 183.5 63 226 49.4 256c13.6 30 40.2 72.5 78.6 108.3C169.2 402.4 222.8 432 288 432s118.8-29.6 159.9-67.7C486.4 328.5 513 286 526.6 256c-13.6-30-40.2-72.5-78.6-108.3C406.8 109.6 353.2 80 288 80zM95.4 112.6C142.5 68.8 207.2 32 288 32s145.5 36.8 192.6 80.6c46.8 43.5 78.1 95.4 93 131.1c3.3 7.9 3.3 16.7 0 24.6c-14.9 35.7-46.2 87.7-93 131.1C433.5 443.2 368.8 480 288 480s-145.5-36.8-192.6-80.6C48.6 356 17.3 304 2.5 268.3c-3.3-7.9-3.3-16.7 0-24.6C17.3 208 48.6 156 95.4 112.6zM288 336c44.2 0 80-35.8 80-80s-35.8-80-80-80c-.7 0-1.3 0-2 0c1.3 5.1 2 10.5 2 16c0 35.3-28.7 64-64 64c-5.5 0-10.9-.7-16-2c0 .7 0 1.3 0 2c0 44.2 35.8 80 80 80zm0-208a128 128 0 1 1 0 256 128 128 0 1 1 0-256z"
-                                  fill="currentColor"
-                                />
-                              </svg>
-                               
-                              Everyone on localhost
-                            </span>
+                            Domicile Attachment
                           </p>
-                        </div>
-                      </div>
-                    </div>
-                    <div
-                      class="pt-40px"
-                    >
-                      <p
-                        class="h5 font-weight-bold m-0 pb-1.5"
-                        data-hj-suppress="true"
-                      >
-                        LinkedIn
-                      </p>
-                      <div
-                        class="p-0 m-0"
-                      >
-                        <button
-                          class="p-0 text-left btn btn-link lh-36px"
-                          tabindex="0"
-                          type="button"
-                        >
-                          <svg
-                            aria-hidden="true"
-                            class="svg-inline--fa fa-plus fa-xs mr-1"
-                            data-icon="plus"
-                            data-prefix="fas"
-                            focusable="false"
-                            role="img"
-                            viewBox="0 0 448 512"
-                            xmlns="http://www.w3.org/2000/svg"
+                          <div
+                            class="d-flex flex-wrap align-items-center"
                           >
-                            <path
-                              d="M256 80c0-17.7-14.3-32-32-32s-32 14.3-32 32l0 144L48 224c-17.7 0-32 14.3-32 32s14.3 32 32 32l144 0 0 144c0 17.7 14.3 32 32 32s32-14.3 32-32l0-144 144 0c17.7 0 32-14.3 32-32s-14.3-32-32-32l-144 0 0-144z"
-                              fill="currentColor"
-                            />
-                          </svg>
-                          Add 
-                          LinkedIn
-                        </button>
-                      </div>
+                            <button
+                              class="btn btn-outline-primary btn-sm"
+                              type="button"
+                            >
+                              Upload domicile attachment
+                            </button>
+                          </div>
+                          <input
+                            accept=".jpg,.jpeg,.png,.webp,.pdf"
+                            class="d-none"
+                            id="basicInformation-domicile_attachment"
+                            type="file"
+                          />
+                        </div>
+                        <div
+                          class="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center"
+                        >
+                          <div
+                            class="row form-group flex-shrink-0 flex-grow-1 m-0 p-0"
+                          >
+                            <div
+                              class="p-0 m-0"
+                            >
+                              <button
+                                aria-disabled="false"
+                                aria-live="assertive"
+                                class="pgn__stateful-btn pgn__stateful-btn-state-null btn btn-primary"
+                                type="submit"
+                              >
+                                <span
+                                  class="d-flex align-items-center justify-content-center"
+                                >
+                                  <span>
+                                    Save and Next
+                                  </span>
+                                </span>
+                              </button>
+                            </div>
+                          </div>
+                        </div>
+                      </form>
                     </div>
                   </div>
                 </div>
@@ -2319,7 +3450,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
               >
                 <div
                   class="certificate-type-illustration"
-                  style="background-image: url(icon/mock/path);"
+                  style="background-image: url("icon/mock/path");"
                 />
                 <div
                   class="d-flex flex-column position-relative p-0 width-314px"

--- a/src/profile/biodata/BiodataFilePreview.jsx
+++ b/src/profile/biodata/BiodataFilePreview.jsx
@@ -1,0 +1,182 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Button, OverlayTrigger, Tooltip,
+} from '@openedx/paragon';
+import {
+  DeleteOutline, EditOutline, Preview, UploadFile,
+} from '@openedx/paragon/icons';
+
+import { getFilePreview } from './utils';
+
+function openPreview(previewUrl) {
+  if (!previewUrl || typeof window === 'undefined') {
+    return;
+  }
+
+  const openedWindow = window.open(previewUrl, '_blank', 'noopener,noreferrer');
+  if (openedWindow) {
+    openedWindow.opener = null;
+    return;
+  }
+
+  window.location.assign(previewUrl);
+}
+
+function renderTooltip(label, id) {
+  return (
+    <Tooltip variant="light" id={id}>
+      <p className="h6 font-weight-normal m-0 p-0">{label}</p>
+    </Tooltip>
+  );
+}
+
+const FileIconButton = ({
+  label,
+  icon: IconComponent,
+  variant,
+  disabled,
+  onClick,
+}) => (
+  <OverlayTrigger
+    placement="top"
+    overlay={renderTooltip(label, `biodata-file-action-${label.toLowerCase().replace(/\s+/g, '-')}`)}
+  >
+    <Button
+      type="button"
+      size="sm"
+      variant={variant}
+      className="d-inline-flex align-items-center justify-content-center mr-2 mb-2 p-2"
+      disabled={disabled}
+      aria-label={label}
+      onClick={onClick}
+      style={{ width: '2.25rem', height: '2.25rem' }}
+    >
+      <IconComponent aria-hidden focusable="false" />
+    </Button>
+  </OverlayTrigger>
+);
+
+const BiodataFileActions = ({
+  field,
+  fileValue,
+  disabled,
+  onReplace,
+  onRemove,
+}) => {
+  const preview = getFilePreview(fileValue);
+
+  return (
+    <div className="d-flex flex-wrap align-items-center">
+      {preview?.canOpen && (
+        <FileIconButton
+          label={`Preview ${field.label}`}
+          icon={Preview}
+          variant="outline-primary"
+          disabled={false}
+          onClick={() => openPreview(preview.url)}
+        />
+      )}
+      <FileIconButton
+        label={fileValue ? `Replace ${field.label}` : `Upload ${field.label}`}
+        icon={fileValue ? EditOutline : UploadFile}
+        variant="outline-primary"
+        disabled={disabled}
+        onClick={onReplace}
+      />
+      {fileValue && (
+        <FileIconButton
+          label={`Remove ${field.label}`}
+          icon={DeleteOutline}
+          variant="outline-danger"
+          disabled={disabled}
+          onClick={onRemove}
+        />
+      )}
+    </div>
+  );
+};
+
+const BiodataFilePreview = ({ field, fileValue }) => {
+  const preview = getFilePreview(fileValue);
+
+  if (!preview) {
+    return <p className="small text-muted mb-0">No file uploaded</p>;
+  }
+
+  return (
+    <div className="mt-2">
+      {preview.kind === 'image' && preview.url && (
+        <img
+          src={preview.url}
+          alt={`${field.label} preview`}
+          className="border rounded p-2 bg-white"
+          style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
+          onError={(event) => {
+            event.currentTarget.classList.add('d-none');
+          }}
+        />
+      )}
+      {preview.kind !== 'image' && (
+        <p className="small text-muted mb-0">
+          <span className="badge badge-light border text-muted mr-2">
+            {preview.kind === 'pdf' ? 'PDF' : 'File'}
+          </span>
+          {preview.name}
+        </p>
+      )}
+      {preview.kind === 'image' && (
+        <p className="small text-muted mt-2 mb-0">{preview.name}</p>
+      )}
+    </div>
+  );
+};
+
+FileIconButton.propTypes = {
+  label: PropTypes.string.isRequired,
+  icon: PropTypes.elementType.isRequired,
+  variant: PropTypes.string.isRequired,
+  disabled: PropTypes.bool,
+  onClick: PropTypes.func.isRequired,
+};
+
+FileIconButton.defaultProps = {
+  disabled: false,
+};
+
+BiodataFileActions.propTypes = {
+  field: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+  }).isRequired,
+  fileValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({}),
+  ]),
+  disabled: PropTypes.bool,
+  onReplace: PropTypes.func.isRequired,
+  onRemove: PropTypes.func.isRequired,
+};
+
+BiodataFileActions.defaultProps = {
+  fileValue: null,
+  disabled: false,
+};
+
+BiodataFilePreview.propTypes = {
+  field: PropTypes.shape({
+    label: PropTypes.string.isRequired,
+  }).isRequired,
+  fileValue: PropTypes.oneOfType([
+    PropTypes.string,
+    PropTypes.shape({}),
+  ]),
+};
+
+BiodataFilePreview.defaultProps = {
+  fileValue: null,
+};
+
+export {
+  BiodataFileActions,
+  BiodataFilePreview,
+};

--- a/src/profile/biodata/BiodataProfileSections.jsx
+++ b/src/profile/biodata/BiodataProfileSections.jsx
@@ -2,202 +2,571 @@ import React, {
   useEffect, useMemo, useRef, useState,
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import {
-  Card, Collapsible, Nav,
-} from '@openedx/paragon';
+import { Card, Nav } from '@openedx/paragon';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { faCheck, faExclamation } from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 
 import { BIODATA_SECTIONS } from './config';
 import BiodataSection from './BiodataSection';
-import EditButton from '../forms/elements/EditButton';
 import {
-  openForm, closeForm, saveProfile, updateDraft,
+  closeForm, saveProfile, saveProfileFailure, updateDraft,
 } from '../data/actions';
 import {
+  BIODATA_DATE_VALIDATION_MESSAGES,
   getSanitizedSectionData,
+  getExtendedProfileValue,
+  getSectionError,
+  getSectionErrorSummary,
   getSectionInitialData,
-  isSingleMaritalStatus,
+  getSectionSubmittedFieldName,
   sectionHasValue,
+  sectionIsComplete,
+  shouldShowSpouseInformation,
+  validateSectionDateRules,
+  validateSectionDraft,
 } from './utils';
 
-const buildExpandedSectionsState = (sections, openSectionId = null) => sections.reduce(
-  (accumulator, section) => ({
-    ...accumulator,
-    [section.id]: section.id === openSectionId,
-  }),
-  {},
-);
+const getVisibleSections = (maritalStatus, sections = BIODATA_SECTIONS) => sections.filter((section) => (
+  section.id !== 'spouseInformation' || shouldShowSpouseInformation(maritalStatus)
+));
+
+const getStepperSections = (sections) => {
+  const spouseSection = sections.find(section => section.id === 'spouseInformation');
+  const sectionsWithoutSpouse = sections.filter(section => section.id !== 'spouseInformation');
+
+  if (!spouseSection) {
+    return sectionsWithoutSpouse;
+  }
+
+  return [
+    sectionsWithoutSpouse[0],
+    spouseSection,
+    ...sectionsWithoutSpouse.slice(1),
+  ].filter(Boolean);
+};
+
+const buildStepState = (sections, extendedProfile) => sections.reduce((accumulator, section) => {
+  const savedData = getSectionInitialData(section, extendedProfile);
+  accumulator[section.id] = {
+    completed: sectionIsComplete(section, savedData),
+    error: false,
+  };
+  return accumulator;
+}, {});
+
+const isSectionCompleteForNavigation = (
+  section,
+  extendedProfile,
+  completedSectionId = null,
+  completedSectionState = false,
+) => {
+  if (section.id === completedSectionId) {
+    return completedSectionState;
+  }
+
+  return sectionIsComplete(section, getSectionInitialData(section, extendedProfile));
+};
+
+const getNextIncompleteVisibleSectionId = (
+  sections,
+  sectionId,
+  extendedProfile,
+  completedSectionId = null,
+  completedSectionState = false,
+) => {
+  const currentIndex = sections.findIndex(section => section.id === sectionId);
+  if (currentIndex === -1) {
+    return sectionId;
+  }
+
+  const nextIncompleteSection = sections
+    .slice(currentIndex + 1)
+    .find(section => !isSectionCompleteForNavigation(
+      section,
+      extendedProfile,
+      completedSectionId,
+      completedSectionState,
+    ));
+
+  return nextIncompleteSection?.id || sections[currentIndex + 1]?.id || sectionId;
+};
+
+const getStepStatusLabel = (stepState, isActive) => {
+  if (stepState?.error) {
+    return stepState.errorSummary || 'Needs attention';
+  }
+
+  if (stepState?.completed) {
+    return 'Completed';
+  }
+
+  return isActive ? 'Current' : 'Not started';
+};
+
+const isTruthyFlag = value => value === true || String(value || '').trim().toLowerCase() === 'true';
+
+const getSectionCompletedState = (section, savedData) => sectionIsComplete(section, savedData);
+
+const getResumeSectionId = (sections, extendedProfile) => {
+  const firstIncompleteSection = sections.find(section => !sectionIsComplete(
+    section,
+    getSectionInitialData(section, extendedProfile),
+  ));
+
+  return firstIncompleteSection?.id || sections[sections.length - 1]?.id || null;
+};
 
 const BiodataProfileSections = () => {
   const dispatch = useDispatch();
-  const sectionsContainerRef = useRef(null);
   const {
     account,
     drafts,
     errors,
     saveState,
-    currentlyEditingField,
     isAuthenticatedUserProfile,
   } = useSelector((state) => state.profilePage);
   const extendedProfile = useMemo(() => account?.extendedProfile || [], [account?.extendedProfile]);
   const accountUsername = account?.username;
-  const [pendingScrollSection, setPendingScrollSection] = useState(null);
+  const previousSaveState = useRef(saveState);
+  const hasResolvedInitialStep = useRef(false);
+  const [pendingSaveStepId, setPendingSaveStepId] = useState(null);
+  const stepperSections = useMemo(() => getStepperSections(BIODATA_SECTIONS), []);
+  const [activeStepId, setActiveStepId] = useState(stepperSections[0].id);
+  const [stepStateById, setStepStateById] = useState(() => buildStepState(stepperSections, []));
+  const [pendingScrollSectionId, setPendingScrollSectionId] = useState(null);
+  const [pendingReturnSectionId, setPendingReturnSectionId] = useState(null);
+
   const basicInformationData = useMemo(() => getSanitizedSectionData(
     BIODATA_SECTIONS[0],
     drafts.basicInformation || getSectionInitialData(BIODATA_SECTIONS[0], extendedProfile),
   ), [drafts.basicInformation, extendedProfile]);
+
   const visibleSections = useMemo(
-    () => BIODATA_SECTIONS.filter((section) => (
-      section.id !== 'spouseInformation' || !isSingleMaritalStatus(basicInformationData.marital_status)
-    )),
-    [basicInformationData.marital_status],
+    () => getVisibleSections(basicInformationData.marital_status, stepperSections),
+    [basicInformationData.marital_status, stepperSections],
+  );
+  const hasDeclarationLockFlag = isTruthyFlag(
+    getExtendedProfileValue(extendedProfile, getSectionSubmittedFieldName('declaration')),
+  );
+  const isBiodataLocked = hasDeclarationLockFlag;
+
+  const activeSection = useMemo(
+    () => visibleSections.find(section => section.id === activeStepId) || visibleSections[0],
+    [activeStepId, visibleSections],
   );
 
-  const [activeSection, setActiveSection] = useState(BIODATA_SECTIONS[0].id);
-  const [expandedSections, setExpandedSections] = useState(() => (
-    buildExpandedSectionsState(BIODATA_SECTIONS, BIODATA_SECTIONS[0].id)
-  ));
+  useEffect(() => {
+    setStepStateById(previousState => visibleSections.reduce((accumulator, section) => {
+      const savedData = getSectionInitialData(section, extendedProfile);
+      const previousStepState = previousState[section.id] || {};
+      const completed = getSectionCompletedState(section, savedData);
+
+      accumulator[section.id] = {
+        completed,
+        error: previousStepState.error || Boolean(getSectionError(section, errors)),
+        errorSummary: getSectionErrorSummary(section, errors),
+      };
+      return accumulator;
+    }, {}));
+  }, [errors, extendedProfile, visibleSections]);
 
   useEffect(() => {
-    if (visibleSections.some((section) => section.id === activeSection)) {
+    hasResolvedInitialStep.current = false;
+  }, [accountUsername]);
+
+  useEffect(() => {
+    if (!accountUsername || hasResolvedInitialStep.current || visibleSections.length === 0) {
       return;
     }
 
-    const fallbackSectionId = visibleSections[0]?.id || null;
-    setActiveSection(fallbackSectionId);
-    setExpandedSections(buildExpandedSectionsState(visibleSections, fallbackSectionId));
-    setPendingScrollSection(null);
-  }, [activeSection, visibleSections]);
+    const resumeSectionId = getResumeSectionId(visibleSections, extendedProfile);
+    if (resumeSectionId) {
+      setActiveStepId(resumeSectionId);
+    }
+    hasResolvedInitialStep.current = true;
+  }, [accountUsername, extendedProfile, visibleSections]);
 
   useEffect(() => {
-    if (!pendingScrollSection || !expandedSections[pendingScrollSection]) {
+    if (!visibleSections.some(section => section.id === activeStepId)) {
+      setActiveStepId(visibleSections[0]?.id || null);
+    }
+  }, [activeStepId, visibleSections]);
+
+  useEffect(() => {
+    if (!pendingScrollSectionId || activeSection?.id !== pendingScrollSectionId) {
       return undefined;
     }
 
     const timeoutId = window.setTimeout(() => {
-      const target = document.getElementById(`biodata-section-${pendingScrollSection}`);
-      const container = sectionsContainerRef.current;
-      const sidebarLink = document.querySelector(`[data-biodata-nav="${pendingScrollSection}"]`);
+      const target = document.getElementById(`biodata-section-${pendingScrollSectionId}`);
+      const sidebarLink = document.querySelector(`[data-biodata-nav="${pendingScrollSectionId}"]`);
 
-      if (!target || !container || !sidebarLink) {
+      if (!target || !sidebarLink) {
+        setPendingScrollSectionId(null);
         return;
       }
 
-      const targetTop = target.getBoundingClientRect().top + window.scrollY;
-      const containerTop = container.getBoundingClientRect().top + window.scrollY;
-      const sidebarTop = sidebarLink.getBoundingClientRect().top + window.scrollY;
-      const nextScrollTop = Math.max(
-        window.scrollY + (targetTop - sidebarTop),
-        containerTop - 16,
-      );
+      const targetTop = target.getBoundingClientRect().top;
+      const sidebarTop = sidebarLink.getBoundingClientRect().top;
 
       window.scrollTo({
-        top: nextScrollTop,
+        top: Math.max(window.scrollY + targetTop - sidebarTop, 0),
         behavior: 'smooth',
       });
-      setPendingScrollSection(null);
-    }, 250);
+      setPendingScrollSectionId(null);
+    }, 50);
 
     return () => window.clearTimeout(timeoutId);
-  }, [expandedSections, pendingScrollSection]);
+  }, [activeSection, pendingScrollSectionId]);
 
-  if (!accountUsername) {
+  useEffect(() => {
+    const previousState = previousSaveState.current;
+    previousSaveState.current = saveState;
+
+    if (!pendingSaveStepId || previousState === saveState) {
+      return;
+    }
+
+    if (saveState === 'complete') {
+      const savedSection = visibleSections.find(section => section.id === pendingSaveStepId);
+      const completed = savedSection
+        ? sectionIsComplete(savedSection, getSectionInitialData(savedSection, extendedProfile))
+        : false;
+
+      setStepStateById(previousStateById => ({
+        ...previousStateById,
+        [pendingSaveStepId]: {
+          ...previousStateById[pendingSaveStepId],
+          completed,
+          error: false,
+        },
+      }));
+      const nextSectionId = pendingReturnSectionId
+        || getNextIncompleteVisibleSectionId(
+          visibleSections,
+          pendingSaveStepId,
+          extendedProfile,
+          pendingSaveStepId,
+          completed,
+        );
+      setActiveStepId(nextSectionId);
+      setPendingScrollSectionId(nextSectionId);
+      setPendingSaveStepId(null);
+      setPendingReturnSectionId(null);
+    }
+
+    if (saveState === 'error') {
+      setStepStateById(previousStateById => ({
+        ...previousStateById,
+        [pendingSaveStepId]: {
+          ...previousStateById[pendingSaveStepId],
+          completed: false,
+          error: true,
+          errorSummary: getSectionErrorSummary(
+            visibleSections.find(section => section.id === pendingSaveStepId) || {},
+            errors,
+          ),
+        },
+      }));
+      setActiveStepId(pendingSaveStepId);
+      setPendingScrollSectionId(pendingSaveStepId);
+      setPendingSaveStepId(null);
+    }
+  }, [drafts, errors, extendedProfile, pendingReturnSectionId, pendingSaveStepId, saveState, visibleSections]);
+
+  if (!accountUsername || !activeSection) {
     return null;
   }
 
-  const openSectionFromSidebar = (sectionId) => {
-    setActiveSection(sectionId);
-    setExpandedSections(buildExpandedSectionsState(visibleSections, sectionId));
-    setPendingScrollSection(sectionId);
+  const activeSectionSavedData = getSectionInitialData(activeSection, extendedProfile);
+  const activeSectionHasSavedContent = sectionHasValue(activeSection, activeSectionSavedData);
+
+  const getSectionDraftData = section => getSanitizedSectionData(
+    section,
+    drafts[section.id] || getSectionInitialData(section, extendedProfile),
+  );
+
+  const sectionNeedsAttention = (section) => {
+    const sectionData = getSectionDraftData(section);
+
+    return Object.keys(validateSectionDraft(section, sectionData)).length > 0
+      || !sectionIsComplete(section, sectionData);
   };
 
-  const toggleSection = (sectionId, isOpen) => {
-    setActiveSection(sectionId);
-    setExpandedSections(buildExpandedSectionsState(visibleSections, isOpen ? sectionId : null));
+  const getFirstIncompleteSectionBefore = (sectionId) => {
+    const currentSectionIndex = visibleSections.findIndex(section => section.id === sectionId);
+
+    if (currentSectionIndex <= 0) {
+      return null;
+    }
+
+    return visibleSections
+      .slice(0, currentSectionIndex)
+      .find(section => sectionNeedsAttention(section)) || null;
+  };
+
+  const getFirstBlockedSectionBefore = (sectionId) => {
+    const currentSectionIndex = visibleSections.findIndex(section => section.id === sectionId);
+
+    if (currentSectionIndex <= 0) {
+      return null;
+    }
+
+    return visibleSections.slice(0, currentSectionIndex).find((section) => {
+      const sectionData = getSectionDraftData(section);
+
+      return Object.keys(validateSectionDraft(section, sectionData)).length > 0
+        || !sectionIsComplete(section, sectionData);
+    }) || null;
+  };
+
+  const markSectionNeedsAttention = (section) => {
+    const sectionData = getSectionDraftData(section);
+    const validationErrors = validateSectionDraft(section, sectionData);
+
+    dispatch(updateDraft(section.id, sectionData));
+    if (Object.keys(validationErrors).length > 0) {
+      dispatch(saveProfileFailure(validationErrors));
+    }
+    setStepStateById(previousStateById => ({
+      ...previousStateById,
+      [section.id]: {
+        ...previousStateById[section.id],
+        completed: false,
+        error: true,
+        errorSummary: getSectionErrorSummary(section, validationErrors)
+          || 'Please complete this section before continuing.',
+      },
+    }));
+  };
+
+  const moveToSection = (sectionId) => {
+    setActiveStepId(sectionId);
+    setPendingScrollSectionId(sectionId);
+  };
+
+  const handleStepClick = (sectionId) => {
+    if (sectionId === 'declaration') {
+      const incompleteSection = getFirstBlockedSectionBefore(sectionId)
+        || getFirstIncompleteSectionBefore(sectionId);
+
+      if (incompleteSection) {
+        markSectionNeedsAttention(incompleteSection);
+        setPendingReturnSectionId(sectionId);
+        moveToSection(incompleteSection.id);
+        return;
+      }
+    }
+
+    setPendingReturnSectionId(null);
+    moveToSection(sectionId);
   };
 
   const handleCloseSection = (sectionId) => {
     dispatch(closeForm(sectionId));
-    setExpandedSections(buildExpandedSectionsState(visibleSections, null));
+  };
+
+  const handleDraftChange = (sectionId, value) => {
+    const section = visibleSections.find(item => item.id === sectionId);
+    const sanitizedData = section ? getSanitizedSectionData(section, value) : value;
+    const dateValidationErrors = section ? validateSectionDateRules(section, sanitizedData) : {};
+    const hasDateValidationErrors = Object.keys(dateValidationErrors).length > 0;
+
+    dispatch(updateDraft(sectionId, sanitizedData));
+
+    if (!section) {
+      return;
+    }
+
+    if (hasDateValidationErrors) {
+      dispatch(saveProfileFailure(dateValidationErrors));
+      setStepStateById(previousStateById => ({
+        ...previousStateById,
+        [section.id]: {
+          ...previousStateById[section.id],
+          completed: false,
+          error: true,
+          dateValidationError: true,
+          errorSummary: getSectionErrorSummary(section, dateValidationErrors),
+        },
+      }));
+      return;
+    }
+
+    setStepStateById(previousStateById => {
+      const previousSectionState = previousStateById[section.id] || {};
+      if (
+        !previousSectionState.dateValidationError
+        && !BIODATA_DATE_VALIDATION_MESSAGES.includes(previousSectionState.errorSummary)
+      ) {
+        return previousStateById;
+      }
+
+      return {
+        ...previousStateById,
+        [section.id]: {
+          ...previousSectionState,
+          error: false,
+          dateValidationError: false,
+          errorSummary: '',
+        },
+      };
+    });
+  };
+
+  const handleSaveAndNext = (sectionId) => {
+    const section = visibleSections.find(item => item.id === sectionId);
+    if (!section || !accountUsername) {
+      return;
+    }
+
+    const nextSectionData = getSectionDraftData(section);
+
+    if (section.id === 'declaration') {
+      const incompleteSection = getFirstBlockedSectionBefore(section.id)
+        || getFirstIncompleteSectionBefore(section.id);
+
+      if (incompleteSection) {
+        markSectionNeedsAttention(incompleteSection);
+        setPendingReturnSectionId(section.id);
+        moveToSection(incompleteSection.id);
+        return;
+      }
+    }
+
+    const validationErrors = validateSectionDraft(section, nextSectionData);
+    if (Object.keys(validationErrors).length > 0) {
+      dispatch(updateDraft(section.id, nextSectionData));
+      dispatch(saveProfileFailure(validationErrors));
+      setStepStateById(previousStateById => ({
+        ...previousStateById,
+        [section.id]: {
+          ...previousStateById[section.id],
+          completed: false,
+          error: true,
+          errorSummary: getSectionErrorSummary(section, validationErrors),
+        },
+      }));
+      moveToSection(section.id);
+      return;
+    }
+
+    dispatch(updateDraft(section.id, nextSectionData));
+    setPendingSaveStepId(section.id);
+    dispatch(saveProfile(section.id, accountUsername));
   };
 
   return (
-    <div>
-      <div className="row">
-        <div className="col-lg-3 mb-4 mb-lg-0">
-          <Card className="position-lg-sticky" style={{ top: '0' }}>
-            <Card.Section>
-              <Nav variant="pills" className="flex-column">
-                {visibleSections.map((section) => (
-                  <Nav.Item key={section.id}>
-                    <Nav.Link
-                      active={activeSection === section.id}
-                      data-biodata-nav={section.id}
-                      className="mb-2"
-                      onClick={() => openSectionFromSidebar(section.id)}
-                    >
-                      <div className="font-weight-bold">{section.title}</div>
-                    </Nav.Link>
-                  </Nav.Item>
-                ))}
-              </Nav>
-            </Card.Section>
-          </Card>
-        </div>
-        <div ref={sectionsContainerRef} className="col-lg-9">
-          {visibleSections.map((section) => (
-            <div key={section.id} id={`biodata-section-${section.id}`} className="mb-3">
-              {(() => {
+    <div className="row">
+      <div className="col-lg-3 mb-4 mb-lg-0">
+        <Card className="position-lg-sticky" style={{ top: '0' }}>
+          <Card.Section>
+            <Nav variant="pills" className="flex-column">
+              {visibleSections.map((section, index) => {
+                const isActive = activeSection.id === section.id;
+                const isLastVisibleStep = index === visibleSections.length - 1;
+                const stepState = stepStateById[section.id] || {};
+                const statusLabel = getStepStatusLabel(stepState, isActive);
                 const savedData = getSectionInitialData(section, extendedProfile);
-                const hasSavedContent = sectionHasValue(section, savedData);
 
                 return (
-                  <Collapsible
-                    open={expandedSections[section.id]}
-                    onToggle={(isOpen) => toggleSection(section.id, isOpen)}
-                    title={(
-                      <div className={classNames('d-flex w-100 align-items-center justify-content-between pr-2')}>
-                        <div>
-                          <div className="font-weight-bold text-gray-900">{section.title}</div>
-                          <div className="small text-muted">{section.helperText}</div>
-                        </div>
-                        {isAuthenticatedUserProfile && currentlyEditingField !== section.id && (
-                          <EditButton
-                            className="p-1.5"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              dispatch(openForm(section.id));
-                            }}
+                  <Nav.Item key={section.id}>
+                    <Nav.Link
+                      active={isActive}
+                      data-biodata-nav={section.id}
+                      className={classNames(
+                        'mb-2 d-flex align-items-stretch text-left position-relative',
+                        { 'border border-danger': stepState.error && !isActive },
+                      )}
+                      onClick={() => handleStepClick(section.id)}
+                    >
+                      <span className="d-flex flex-column align-items-center flex-shrink-0 mr-2" aria-hidden="true">
+                        <span
+                          className={classNames(
+                            'd-inline-flex align-items-center justify-content-center flex-shrink-0',
+                            {
+                              'text-primary': isActive && !stepState.error,
+                              'text-success': stepState.completed && !isActive && !stepState.error,
+                              'text-danger': stepState.error,
+                              'text-gray-700': !isActive && !stepState.completed && !stepState.error,
+                            },
+                          )}
+                          style={{ width: '1.25rem', minHeight: '1.75rem', zIndex: 1 }}
+                        >
+                          {stepState.error && <FontAwesomeIcon icon={faExclamation} size="sm" />}
+                          {!stepState.error && stepState.completed && <FontAwesomeIcon icon={faCheck} size="sm" />}
+                          {!stepState.error && !stepState.completed && (
+                            <span
+                              className={classNames(
+                                'd-inline-block rounded-circle',
+                                isActive ? 'bg-primary' : 'bg-gray-700',
+                              )}
+                              style={{ width: '0.5rem', height: '0.5rem' }}
+                            />
+                          )}
+                        </span>
+                        {!isLastVisibleStep && (
+                          <span
+                            className={classNames(
+                              'border-left flex-grow-1 mt-1 mb-n2',
+                              stepState.completed && !stepState.error ? 'border-success' : 'border-light-500',
+                            )}
+                            style={{ minHeight: '1.25rem' }}
                           />
                         )}
-                      </div>
-                    )}
-                    styling="card"
-                    className="shadow-sm"
-                  >
-                    <Card.Section>
-                      <BiodataSection
-                        section={section}
-                        extendedProfile={extendedProfile}
-                        draftValue={drafts[section.id]}
-                        errors={errors}
-                        saveState={saveState}
-                        isAuthenticatedUserProfile={isAuthenticatedUserProfile}
-                        isEditing={currentlyEditingField === section.id}
-                        forceEditingWhenEmpty={expandedSections[section.id] && !hasSavedContent}
-                        onClose={handleCloseSection}
-                        onSubmit={(formId) => dispatch(saveProfile(formId, accountUsername))}
-                        onDraftChange={(formId, value) => dispatch(updateDraft(formId, value))}
-                        spacingClassName="pt-0"
-                        showInlineTitle={false}
-                      />
-                    </Card.Section>
-                  </Collapsible>
+                      </span>
+                      <span className="pb-2">
+                        <span className="font-weight-bold d-block">{section.title}</span>
+                        <span className={classNames('small d-block', stepState.error ? 'text-danger' : 'text-muted')}>
+                          {statusLabel}
+                        </span>
+                        {!sectionHasValue(section, savedData) && !stepState.completed && !stepState.error && (
+                          <span className="small text-muted d-block">No information added</span>
+                        )}
+                      </span>
+                    </Nav.Link>
+                  </Nav.Item>
                 );
-              })()}
+              })}
+            </Nav>
+          </Card.Section>
+        </Card>
+      </div>
+      <div className="col-lg-9">
+        <Card id={`biodata-section-${activeSection.id}`} className="shadow-sm">
+          <Card.Section>
+            <div className="mb-3">
+              <div className="font-weight-bold text-gray-900 h5 mb-1">{activeSection.title}</div>
+              {activeSection.helperText && (
+                <div className="small text-muted">{activeSection.helperText}</div>
+              )}
             </div>
-          ))}
-        </div>
+            <BiodataSection
+              section={activeSection}
+              extendedProfile={extendedProfile}
+              draftValue={drafts[activeSection.id]}
+              errors={errors}
+              saveState={saveState}
+              isAuthenticatedUserProfile={isAuthenticatedUserProfile}
+              isEditing={isAuthenticatedUserProfile}
+              isLocked={isBiodataLocked}
+              forceEditingWhenEmpty={!activeSectionHasSavedContent}
+              onClose={handleCloseSection}
+              onSubmit={handleSaveAndNext}
+              onDraftChange={handleDraftChange}
+              spacingClassName="pt-0"
+              showInlineTitle={false}
+              showCancelButton={false}
+              showSubmitButton={!isBiodataLocked}
+              submitLabels={{
+                default: 'Save and Next',
+                pending: 'Saving',
+                complete: 'Saved',
+              }}
+            />
+          </Card.Section>
+        </Card>
       </div>
     </div>
   );

--- a/src/profile/biodata/BiodataSection.jsx
+++ b/src/profile/biodata/BiodataSection.jsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Button, Form, StatefulButton,
@@ -7,15 +7,24 @@ import {
 import SwitchContent from '../forms/elements/SwitchContent';
 
 import { PROFILE_FIELD_TYPES } from './config';
+import { BiodataFileActions, BiodataFilePreview } from './BiodataFilePreview';
 import RepeatableFieldGroup from './RepeatableFieldGroup';
 import {
+  createFileUploadValue,
   createEmptyRepeatableRow,
   getSectionError,
+  getSectionErrorFields,
+  getSectionErrorSummary,
   getSectionInitialData,
   getSanitizedSectionData,
-  isSingleMaritalStatus,
-  readFileAsDataUrl,
+  getVisibleSectionFields,
+  getVisibleSectionRepeatables,
+  isProtectedRepeatableColumn,
+  isProtectedRepeatableRow,
+  normalizeRepeatableRows,
+  revokeFilePreviewUrl,
   sectionHasValue,
+  shouldShowSpouseInformation,
 } from './utils';
 
 function renderFieldControl(field, value, onChange, error, disabled = false) {
@@ -89,15 +98,40 @@ function renderReadonlyFile(field, fileValue) {
   return (
     <div className="border rounded p-3 mb-3 bg-light-200">
       <p className="h6 font-weight-bold mb-2">{field.label}</p>
-      <img
-        src={fileValue.dataUrl || fileValue.url}
-        alt={`${field.label} preview`}
-        className="border rounded p-2 bg-white"
-        style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
+      <BiodataFileActions
+        field={field}
+        fileValue={fileValue}
+        disabled
+        onReplace={() => {}}
+        onRemove={() => {}}
       />
-      <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
+      <BiodataFilePreview field={field} fileValue={fileValue} />
     </div>
   );
+}
+
+function revokeSectionFilePreviews(section, data) {
+  (section.fileFields || []).forEach((field) => {
+    revokeFilePreviewUrl(data?.[field.fieldName]);
+  });
+
+  (section.repeatables || []).forEach((repeatable) => {
+    (data?.[repeatable.storageFieldName] || []).forEach((row) => {
+      (repeatable.columns || []).forEach((column) => {
+        if (column.type === PROFILE_FIELD_TYPES.FILE) {
+          revokeFilePreviewUrl(row?.[column.key]);
+        }
+      });
+    });
+  });
+}
+
+function revokeRepeatableRowFilePreviews(row, repeatable) {
+  (repeatable.columns || []).forEach((column) => {
+    if (column.type === PROFILE_FIELD_TYPES.FILE) {
+      revokeFilePreviewUrl(row?.[column.key]);
+    }
+  });
 }
 
 const BiodataSection = ({
@@ -114,6 +148,10 @@ const BiodataSection = ({
   spacingClassName,
   showInlineTitle,
   forceEditingWhenEmpty,
+  showCancelButton,
+  showSubmitButton,
+  submitLabels,
+  isLocked,
 }) => {
   const committedData = useMemo(
     () => getSectionInitialData(section, extendedProfile),
@@ -123,8 +161,21 @@ const BiodataSection = ({
     () => getSanitizedSectionData(section, draftValue || committedData),
     [section, draftValue, committedData],
   );
+  const formDataRef = useRef(formData);
+  const sectionRef = useRef(section);
   const hasContent = sectionHasValue(section, committedData);
   const sectionError = getSectionError(section, errors);
+  const sectionErrorSummary = getSectionErrorSummary(section, errors, formData);
+  const sectionErrorFields = getSectionErrorFields(section, errors, formData);
+
+  useEffect(() => {
+    formDataRef.current = formData;
+    sectionRef.current = section;
+  }, [formData, section]);
+
+  useEffect(() => () => {
+    revokeSectionFilePreviews(sectionRef.current, formDataRef.current);
+  }, []);
 
   if (!isAuthenticatedUserProfile && !hasContent) {
     return null;
@@ -133,6 +184,8 @@ const BiodataSection = ({
   let editMode = 'editing';
   if (!isAuthenticatedUserProfile) {
     editMode = 'static';
+  } else if (isLocked) {
+    editMode = 'readonly';
   } else if (isEditing) {
     editMode = 'editing';
   } else if (hasContent) {
@@ -147,7 +200,7 @@ const BiodataSection = ({
       [fieldName]: value,
     };
 
-    if (section.id === 'basicInformation' && fieldName === 'marital_status' && isSingleMaritalStatus(value)) {
+    if (section.id === 'basicInformation' && fieldName === 'marital_status' && !shouldShowSpouseInformation(value)) {
       nextFormData.number_of_children = '0';
       nextFormData.sons = '0';
       nextFormData.daughters = '0';
@@ -161,17 +214,30 @@ const BiodataSection = ({
     let nextRows = currentRows;
 
     if (action === 'addRow') {
-      nextRows = [...currentRows, createEmptyRepeatableRow(repeatable)];
+      const nextRow = createEmptyRepeatableRow(repeatable);
+      nextRows = [...currentRows, nextRow];
     } else if (action === 'removeRow') {
+      if (isProtectedRepeatableRow(currentRows[payload.rowIndex], repeatable)) {
+        return;
+      }
+      revokeRepeatableRowFilePreviews(currentRows[payload.rowIndex], repeatable);
       nextRows = currentRows.filter((_, index) => index !== payload.rowIndex);
       if (nextRows.length === 0) {
         nextRows = [createEmptyRepeatableRow(repeatable)];
       }
     } else if (action === 'updateCell') {
+      if (
+        payload.columnKey === repeatable.autoPriorityKey
+        || isProtectedRepeatableColumn(currentRows[payload.rowIndex], repeatable, payload.columnKey)
+      ) {
+        return;
+      }
       nextRows = currentRows.map((row, index) => (
         index === payload.rowIndex ? { ...row, [payload.columnKey]: payload.value } : row
       ));
     }
+
+    nextRows = normalizeRepeatableRows(nextRows, repeatable);
 
     onDraftChange(section.id, {
       ...formData,
@@ -184,14 +250,19 @@ const BiodataSection = ({
       return;
     }
 
-    const dataUrl = await readFileAsDataUrl(file);
+    revokeFilePreviewUrl(formData[fieldName]);
+
     onDraftChange(section.id, {
       ...formData,
       [fieldName]: {
-        name: file.name,
-        dataUrl,
+        ...createFileUploadValue(file),
       },
     });
+  };
+
+  const handleFileRemove = (fieldName) => {
+    revokeFilePreviewUrl(formData[fieldName]);
+    handleFieldChange(fieldName, null);
   };
 
   const handleSectionNaChange = (value) => {
@@ -209,11 +280,8 @@ const BiodataSection = ({
   };
 
   const isSectionDisabled = Boolean(section.naFieldName && formData[section.naFieldName]);
-  const visibleFields = (section.fields || []).filter((field) => (
-    section.id !== 'basicInformation'
-    || !['number_of_children', 'sons', 'daughters'].includes(field.fieldName)
-    || !isSingleMaritalStatus(formData.marital_status)
-  ));
+  const visibleFields = getVisibleSectionFields(section, formData);
+  const visibleRepeatables = getVisibleSectionRepeatables(section, formData);
   const renderFormFields = (disabled = false) => (
     <>
       {section.naFieldName && (
@@ -246,7 +314,7 @@ const BiodataSection = ({
                 disabled || isSectionDisabled,
               )}
               {!disabled && error && error.userMessage && (
-                <Form.Control.Feedback hasIcon={false}>
+                <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
                   {error.userMessage}
                 </Form.Control.Feedback>
               )}
@@ -254,7 +322,7 @@ const BiodataSection = ({
           );
         })}
       </div>
-      {(section.repeatables || []).map((repeatable) => (
+      {visibleRepeatables.map((repeatable) => (
         <div key={repeatable.storageFieldName} className="mb-3">
           {repeatable.naFieldName && (
             <Form.Group className="mb-2">
@@ -271,6 +339,7 @@ const BiodataSection = ({
           <RepeatableFieldGroup
             repeatable={repeatable}
             rows={formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)]}
+            errors={errors}
             onChange={(action, payload) => handleRepeatableChange(repeatable, action, payload)}
             disabled={
               disabled
@@ -282,60 +351,48 @@ const BiodataSection = ({
       ))}
       {(section.fileFields || []).map((field) => {
         const fileValue = formData[field.fieldName];
-        if (disabled) {
+        const error = errors[field.fieldName];
+        if (disabled || isSectionDisabled) {
           return <div key={field.fieldName}>{renderReadonlyFile(field, fileValue)}</div>;
         }
 
         return (
-          <div key={field.fieldName} className="border rounded p-3 mb-3 bg-light-200">
+          <div
+            key={field.fieldName}
+            className={`border rounded p-3 mb-3 bg-light-200${error ? ' border-danger' : ''}`}
+          >
             <p className="h6 font-weight-bold mb-2">{field.label}</p>
-            <div className="d-flex flex-wrap align-items-center">
-              <Button
-                type="button"
-                size="sm"
-                variant="outline-primary"
-                onClick={() => {
-                  const input = document.getElementById(`${section.id}-${field.fieldName}`);
-                  if (input) {
-                    input.click();
-                  }
-                }}
-              >
-                {fileValue ? `Replace ${field.label.toLowerCase()}` : `Upload ${field.label.toLowerCase()}`}
-              </Button>
-              {fileValue && (
-                <Button
-                  type="button"
-                  size="sm"
-                  variant="link"
-                  className="text-danger"
-                  onClick={() => handleFieldChange(field.fieldName, null)}
-                >
-                  Remove
-                </Button>
-              )}
-            </div>
+            <BiodataFileActions
+              field={field}
+              fileValue={fileValue}
+              disabled={disabled || isSectionDisabled}
+              onReplace={() => {
+                const input = document.getElementById(`${section.id}-${field.fieldName}`);
+                if (input) {
+                  input.click();
+                }
+              }}
+              onRemove={() => handleFileRemove(field.fieldName)}
+            />
             <input
               id={`${section.id}-${field.fieldName}`}
               type="file"
               accept={field.accept}
               className="d-none"
+              disabled={disabled || isSectionDisabled}
               onChange={(event) => {
                 const input = event.currentTarget;
                 handleFileChange(field.fieldName, event.target.files && event.target.files[0]);
                 input.value = '';
               }}
             />
+            {error && error.userMessage && (
+              <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-2">
+                {error.userMessage}
+              </Form.Control.Feedback>
+            )}
             {fileValue && (
-              <div className="mt-3">
-                <img
-                  src={fileValue.dataUrl || fileValue.url}
-                  alt={`${field.label} preview`}
-                  className="border rounded p-2 bg-white"
-                  style={{ maxWidth: '14rem', maxHeight: '5rem', objectFit: 'contain' }}
-                />
-                <p className="small text-muted mt-2 mb-0">{fileValue.name}</p>
-              </div>
+              <BiodataFilePreview field={field} fileValue={fileValue} />
             )}
           </div>
         );
@@ -366,30 +423,45 @@ const BiodataSection = ({
                 <p className="text-muted small mb-3">{section.helperText}</p>
               )}
               {sectionError && sectionError.userMessage && (
-                <Alert variant="danger" dismissible={false} show className="mb-3">
-                  {sectionError.userMessage}
+                <Alert variant="danger" dismissible={false} show className="mb-3 border-danger">
+                  <p className="font-weight-bold mb-1">
+                    {sectionErrorSummary || 'Please review this section.'}
+                  </p>
+                  {sectionErrorFields.length > 0 && (
+                    <p className="small mb-0">
+                      Highlighted field{sectionErrorFields.length === 1 ? '' : 's'}: {sectionErrorFields.map(({ label }) => label).join(', ')}
+                    </p>
+                  )}
+                  {sectionErrorFields.length === 0 && (
+                    <p className="small mb-0">{sectionError.userMessage}</p>
+                  )}
                 </Alert>
               )}
               {renderFormFields()}
               <div className="d-flex flex-row-reverse flex-wrap justify-content-end align-items-center">
                 <div className="row form-group flex-shrink-0 flex-grow-1 m-0 p-0">
-                  <div className="pr-2 pl-0 m-0">
-                    <Button variant="outline-primary" type="button" onClick={() => onClose(section.id)}>
-                      Cancel
-                    </Button>
-                  </div>
-                  <div className="p-0 m-0">
-                    <StatefulButton
-                      type="submit"
-                      state={saveState === 'error' ? null : saveState}
-                      labels={{
-                        default: 'Save',
-                        pending: 'Saving',
-                        complete: 'Saved',
-                      }}
-                      disabledStates={[]}
-                    />
-                  </div>
+                  {showCancelButton && (
+                    <div className="pr-2 pl-0 m-0">
+                      <Button variant="outline-primary" type="button" onClick={() => onClose(section.id)}>
+                        Cancel
+                      </Button>
+                    </div>
+                  )}
+                  {showSubmitButton && (
+                    <div className="p-0 m-0">
+                      <StatefulButton
+                        type="submit"
+                        state={saveState === 'error' ? null : saveState}
+                        labels={{
+                          default: 'Save',
+                          pending: 'Saving',
+                          complete: 'Saved',
+                          ...submitLabels,
+                        }}
+                        disabledStates={[]}
+                      />
+                    </div>
+                  )}
                 </div>
               </div>
             </form>
@@ -427,14 +499,19 @@ BiodataSection.propTypes = {
       storageFieldName: PropTypes.string.isRequired,
       itemLabel: PropTypes.string.isRequired,
       addButtonLabel: PropTypes.string.isRequired,
+      autoPriorityKey: PropTypes.string,
       naFieldName: PropTypes.string,
       naLabel: PropTypes.string,
+      protectedRowKey: PropTypes.string,
+      protectedRows: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)),
+      protectedColumns: PropTypes.arrayOf(PropTypes.string),
       emptyRow: PropTypes.objectOf(PropTypes.string).isRequired,
       columns: PropTypes.arrayOf(PropTypes.shape({
         key: PropTypes.string.isRequired,
         label: PropTypes.string.isRequired,
         type: PropTypes.string,
         placeholder: PropTypes.string,
+        displayOnly: PropTypes.bool,
       })).isRequired,
     })),
     fileFields: PropTypes.arrayOf(PropTypes.shape({
@@ -467,6 +544,14 @@ BiodataSection.propTypes = {
   spacingClassName: PropTypes.string,
   showInlineTitle: PropTypes.bool,
   forceEditingWhenEmpty: PropTypes.bool,
+  showCancelButton: PropTypes.bool,
+  showSubmitButton: PropTypes.bool,
+  isLocked: PropTypes.bool,
+  submitLabels: PropTypes.shape({
+    default: PropTypes.string,
+    pending: PropTypes.string,
+    complete: PropTypes.string,
+  }),
 };
 
 BiodataSection.defaultProps = {
@@ -477,6 +562,10 @@ BiodataSection.defaultProps = {
   spacingClassName: 'pt-40px',
   showInlineTitle: true,
   forceEditingWhenEmpty: false,
+  showCancelButton: true,
+  showSubmitButton: true,
+  isLocked: false,
+  submitLabels: {},
 };
 
 export default BiodataSection;

--- a/src/profile/biodata/RepeatableFieldGroup.jsx
+++ b/src/profile/biodata/RepeatableFieldGroup.jsx
@@ -3,13 +3,62 @@ import PropTypes from 'prop-types';
 import { Button, Form } from '@openedx/paragon';
 
 import { PROFILE_FIELD_TYPES } from './config';
+import { BiodataFileActions, BiodataFilePreview } from './BiodataFilePreview';
+import {
+  createFileUploadValue,
+  getRepeatableFieldErrorKey,
+  isProtectedRepeatableColumn,
+  isProtectedRepeatableRow,
+  revokeFilePreviewUrl,
+} from './utils';
 
-function renderControl(field, value, onChange, disabled = false) {
+function renderControl(field, value, onChange, error, disabled = false) {
+  if (field.type === PROFILE_FIELD_TYPES.FILE) {
+    const inputId = field.inputId || field.key;
+    return (
+      <div>
+        <BiodataFileActions
+          field={field}
+          fileValue={value}
+          disabled={disabled}
+          onReplace={() => {
+            const input = document.getElementById(inputId);
+            if (input) {
+              input.click();
+            }
+          }}
+          onRemove={() => {
+            revokeFilePreviewUrl(value);
+            onChange(null);
+          }}
+        />
+        <input
+          id={inputId}
+          type="file"
+          accept={field.accept}
+          className="d-none"
+          disabled={disabled}
+          onChange={async (event) => {
+            const input = event.currentTarget;
+            const file = event.target.files && event.target.files[0];
+            if (file) {
+              revokeFilePreviewUrl(value);
+              onChange(createFileUploadValue(file));
+            }
+            input.value = '';
+          }}
+        />
+        <BiodataFilePreview field={field} fileValue={value} />
+      </div>
+    );
+  }
+
   if (field.type === PROFILE_FIELD_TYPES.SELECT) {
     return (
       <Form.Control
         as="select"
         value={value}
+        isInvalid={Boolean(error)}
         disabled={disabled}
         onChange={(event) => onChange(event.target.value)}
       >
@@ -29,6 +78,7 @@ function renderControl(field, value, onChange, disabled = false) {
         rows={3}
         value={value}
         placeholder={field.placeholder}
+        isInvalid={Boolean(error)}
         disabled={disabled}
         onChange={(event) => onChange(event.target.value)}
       />
@@ -40,6 +90,7 @@ function renderControl(field, value, onChange, disabled = false) {
       type={field.type || PROFILE_FIELD_TYPES.TEXT}
       value={value}
       placeholder={field.placeholder}
+      isInvalid={Boolean(error)}
       disabled={disabled}
       onChange={(event) => onChange(event.target.value)}
     />
@@ -49,43 +100,63 @@ function renderControl(field, value, onChange, disabled = false) {
 const RepeatableFieldGroup = ({
   repeatable,
   rows,
+  errors,
   onChange,
   disabled,
 }) => (
   <div>
-    {rows.map((row, rowIndex) => (
-      <div key={row.rowId} className="border rounded p-3 mb-3">
-        <div className="d-flex justify-content-between align-items-center mb-3">
-          <p className="h6 font-weight-bold mb-0">
-            {repeatable.itemLabel} {rowIndex + 1}
-          </p>
-          <Button
-            variant="link"
-            className="p-0 text-danger"
-            type="button"
-            onClick={() => onChange('removeRow', { rowIndex })}
-            disabled={disabled || rows.length === 1}
-          >
-            Remove
-          </Button>
-        </div>
-        <div className="row">
-          {repeatable.columns.map((column) => (
-            <Form.Group
-              key={`${row.rowId}-${column.key}`}
-              className={column.type === PROFILE_FIELD_TYPES.TEXTAREA ? 'col-12 mb-3' : 'col-md-6 mb-3'}
+    {rows.map((row, rowIndex) => {
+      const isProtectedRow = isProtectedRepeatableRow(row, repeatable);
+
+      return (
+        <div key={row.rowId} className="border rounded p-3 mb-3">
+          <div className="d-flex justify-content-between align-items-center mb-3">
+            <p className="h6 font-weight-bold mb-0">
+              {repeatable.itemLabel}{repeatable.showRowNumber === false ? '' : ` ${rowIndex + 1}`}
+            </p>
+            <Button
+              variant="link"
+              className="p-0 text-danger"
+              type="button"
+              onClick={() => onChange('removeRow', { rowIndex })}
+              disabled={disabled || rows.length === 1 || isProtectedRow}
             >
-              <Form.Label>{column.label}</Form.Label>
-              {renderControl(column, row[column.key], (value) => onChange('updateCell', {
-                rowIndex,
-                columnKey: column.key,
-                value,
-              }), disabled)}
-            </Form.Group>
-          ))}
+              Remove
+            </Button>
+          </div>
+          <div className="row">
+            {repeatable.columns.map((column) => {
+              const error = errors[getRepeatableFieldErrorKey(repeatable, row, column.key)] || errors[column.key];
+              const controlField = {
+                ...column,
+                inputId: `${row.rowId}-${column.key}`,
+              };
+              const isControlDisabled = disabled
+                || Boolean(column.displayOnly)
+                || isProtectedRepeatableColumn(row, repeatable, column.key);
+              return (
+                <Form.Group
+                  key={`${row.rowId}-${column.key}`}
+                  className={column.type === PROFILE_FIELD_TYPES.TEXTAREA ? 'col-12 mb-3' : 'col-md-6 mb-3'}
+                >
+                  <Form.Label>{column.label}</Form.Label>
+                  {renderControl(controlField, row[column.key], (value) => onChange('updateCell', {
+                    rowIndex,
+                    columnKey: column.key,
+                    value,
+                  }), error, isControlDisabled)}
+                  {!isControlDisabled && error && error.userMessage && (
+                    <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
+                      {error.userMessage}
+                    </Form.Control.Feedback>
+                  )}
+                </Form.Group>
+              );
+            })}
+          </div>
         </div>
-      </div>
-    ))}
+      );
+    })}
     <Button type="button" variant="link" className="p-0" onClick={() => onChange('addRow')} disabled={disabled}>
       + {repeatable.addButtonLabel}
     </Button>
@@ -97,25 +168,38 @@ RepeatableFieldGroup.propTypes = {
     storageFieldName: PropTypes.string.isRequired,
     itemLabel: PropTypes.string.isRequired,
     addButtonLabel: PropTypes.string.isRequired,
+    showRowNumber: PropTypes.bool,
     columns: PropTypes.arrayOf(PropTypes.shape({
       key: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired,
       placeholder: PropTypes.string,
       type: PropTypes.string,
+      accept: PropTypes.string,
+      displayOnly: PropTypes.bool,
       options: PropTypes.arrayOf(PropTypes.shape({
         value: PropTypes.string,
         label: PropTypes.string,
       })),
     })).isRequired,
+    protectedRowKey: PropTypes.string,
+    protectedRows: PropTypes.arrayOf(PropTypes.objectOf(PropTypes.string)),
+    protectedColumns: PropTypes.arrayOf(PropTypes.string),
   }).isRequired,
   rows: PropTypes.arrayOf(PropTypes.shape({
     rowId: PropTypes.string.isRequired,
   })).isRequired,
+  errors: PropTypes.objectOf(PropTypes.oneOfType([
+    PropTypes.shape({
+      userMessage: PropTypes.string,
+    }),
+    PropTypes.string,
+  ])),
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool,
 };
 
 RepeatableFieldGroup.defaultProps = {
+  errors: {},
   disabled: false,
 };
 

--- a/src/profile/biodata/apiConfig.js
+++ b/src/profile/biodata/apiConfig.js
@@ -7,14 +7,18 @@ export const BIODATA_SECTION_ENDPOINTS = {
   basicInformation: {
     flat: {
       path: 'v1/basic-information/',
+      submissionSupported: true,
       fieldMap: {
         title: 'profile_title',
         full_name: 'profile_full_name',
         preferred_name: 'preferred_calling_name',
         cnic: 'identity_card_number',
+        cnic_front: 'cnic_front',
+        cnic_back: 'cnic_back',
         date_of_birth: 'date_of_birth',
         place_of_birth: 'place_of_birth',
         domicile_district: 'district_of_domicile',
+        domicile_file: 'domicile_file',
         religion: 'religion',
         marital_status: 'marital_status',
         children_count: 'number_of_children',
@@ -26,6 +30,7 @@ export const BIODATA_SECTION_ENDPOINTS = {
   physicalMedicalInformation: {
     flat: {
       path: 'v1/physical-medical/',
+      submissionSupported: true,
       fieldMap: {
         medical_checkup_date: 'last_annual_medical_checkup',
         height: 'height',
@@ -36,6 +41,7 @@ export const BIODATA_SECTION_ENDPOINTS = {
   contactInformation: {
     flat: {
       path: 'v1/contact-information/',
+      submissionSupported: true,
       fieldMap: {
         permanent_address: 'permanent_residential_address',
         permanent_phone: 'permanent_phone_number',
@@ -52,6 +58,7 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       education_records: {
         path: 'v1/education/',
+        submissionSupported: false,
         fieldMap: {
           institute: 'educational_institute',
           attended_from: 'attended_from',
@@ -60,6 +67,7 @@ export const BIODATA_SECTION_ENDPOINTS = {
           year_of_passing: 'year_of_passing',
           grade: 'grade_division',
           subjects: 'subjects_studied',
+          degree_file: 'education_degree_attachment',
         },
       },
     },
@@ -67,12 +75,20 @@ export const BIODATA_SECTION_ENDPOINTS = {
   achievements: {
     flat: {
       path: 'v1/achievements/',
+      submissionSupported: true,
+      fieldMap: {
+        not_applicable: 'achievements_not_applicable',
+        distinctions: 'distinctions',
+        scholarships: 'scholarships',
+        awards: 'awards',
+      },
     },
   },
   languages: {
     repeatables: {
       language_proficiencies: {
         path: 'v1/languages/',
+        submissionSupported: false,
         fieldMap: {
           language: 'language_name',
           speaking: 'speaking_proficiency',
@@ -85,13 +101,24 @@ export const BIODATA_SECTION_ENDPOINTS = {
   employment: {
     flat: {
       path: 'v1/employment/',
+      submissionSupported: true,
       fieldMap: {
+        not_applicable: 'is_first_job',
         employment_gap_details: 'first_employment_gap_details_after_education',
       },
     },
     repeatables: {
       employment_records: {
         path: 'v1/employment-records/',
+        skipWhenFlatFieldEquals: {
+          fieldName: 'not_applicable',
+          value: true,
+        },
+        skipWhenFieldEquals: {
+          fieldName: 'is_first_job',
+          value: 'Yes',
+        },
+        submissionSupported: false,
         fieldMap: {
           organization: 'organization_office',
           designation: 'designation_place_of_posting',
@@ -105,6 +132,13 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       competitive_examinations: {
         path: 'v1/competitive-examinations/',
+        fallbackNaFieldName: 'competitive_examinations_not_applicable',
+        extraFieldMap: {
+          not_applicable: 'competitive_examinations_not_applicable',
+        },
+        extraFieldsMethod: 'post',
+        mergeExtraFieldsIntoRows: true,
+        submissionSupported: false,
         fieldMap: {
           examination_name: 'examination_name',
           agency: 'agency_holding_examination',
@@ -118,25 +152,42 @@ export const BIODATA_SECTION_ENDPOINTS = {
   cssExamDetails: {
     flat: {
       path: 'v1/css-exam-details/',
+      submissionSupported: true,
       fieldMap: {
         roll_number: 'css_roll_number',
         merit_position: 'css_merit_position',
-        service_preferences: 'occupational_service_group_preferences',
         chances_availed: 'css_chances_availed',
         applied_forthcoming: 'applied_for_forthcoming_css_exam',
         intend_forthcoming: 'intend_to_sit_for_forthcoming_css_exam',
         last_chance: 'last_chance_date_year',
+        mark_sheet: 'css_marksheet_attachment',
       },
     },
     repeatables: {
+      occupational_service_group_preferences: {
+        path: 'v1/service-group-preferences/',
+        rowMethod: 'post',
+        batchRows: true,
+        dedupeBy: 'service_group',
+        submissionSupported: false,
+        fieldMap: {
+          service_group: 'service_group',
+          priority: 'priority',
+        },
+      },
       css_subject_marks: {
         path: 'v1/css-subject-marks/',
+        rowMethod: 'post',
+        batchRows: true,
+        dedupeBy: 'subject',
+        submissionSupported: false,
       },
     },
   },
   governmentServiceDetails: {
     flat: {
       path: 'v1/government-service/',
+      submissionSupported: true,
       fieldMap: {
         govt_service_date: 'date_joining_any_govt_service_before_csa',
         dept_name: 'department_name',
@@ -150,6 +201,7 @@ export const BIODATA_SECTION_ENDPOINTS = {
   personalInterests: {
     flat: {
       path: 'v1/personal-interests/',
+      submissionSupported: true,
       fieldMap: {
         games_played: 'games_played',
         game_awards: 'game_distinctions_awards',
@@ -161,6 +213,13 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       foreign_visits: {
         path: 'v1/foreign-visits/',
+        fallbackNaFieldName: 'foreign_visits_not_applicable',
+        extraFieldMap: {
+          not_applicable: 'foreign_visits_not_applicable',
+        },
+        extraFieldsMethod: 'post',
+        mergeExtraFieldsIntoRows: true,
+        submissionSupported: false,
         fieldMap: {
           country: 'country',
           purpose: 'purpose_of_visit',
@@ -174,20 +233,32 @@ export const BIODATA_SECTION_ENDPOINTS = {
   familyInformation: {
     flat: {
       path: 'v1/family-information/',
+      submissionSupported: true,
       fieldMap: {
         father_name: 'father_name',
         father_education: 'father_education',
         father_occupation: 'father_occupation',
-        father_address: 'father_address_phone_number',
+        father_address: 'father_address',
+        father_phone: 'father_phone_number',
         mother_name: 'mother_name',
         mother_education: 'mother_education',
         mother_occupation: 'mother_occupation',
-        mother_address: 'mother_address_phone_number',
+        mother_address: 'mother_address',
+        mother_phone: 'mother_phone_number',
       },
     },
+  },
+  siblings: {
     repeatables: {
       siblings_family_information: {
         path: 'v1/siblings/',
+        fallbackNaFieldName: 'siblings_not_applicable',
+        extraFieldMap: {
+          not_applicable: 'siblings_not_applicable',
+        },
+        extraFieldsMethod: 'post',
+        mergeExtraFieldsIntoRows: true,
+        submissionSupported: false,
         fieldMap: {
           relationship: 'relationship',
           name: 'name',
@@ -202,27 +273,38 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       close_relatives_in_government_service: {
         path: 'v1/government-relatives/',
+        fallbackNaFieldName:
+          'close_relatives_in_government_service_not_applicable',
+        extraFieldMap: {
+          not_applicable:
+            'close_relatives_in_government_service_not_applicable',
+        },
+        extraFieldsMethod: 'post',
+        mergeExtraFieldsIntoRows: true,
+        submissionSupported: false,
       },
     },
   },
   spouseInformation: {
     flat: {
       path: 'v1/spouse-information/',
+      submissionSupported: true,
       fieldMap: {
         spouse_name: 'spouse_name',
         spouse_education: 'spouse_education',
         spouse_occupation: 'spouse_occupation',
-        spouse_address: 'spouse_address_phone_number',
+        spouse_address: 'spouse_address',
+        spouse_phone: 'spouse_phone',
       },
     },
   },
   declaration: {
     flat: {
       path: 'v1/declaration/',
+      submissionSupported: true,
       fieldMap: {
         confirmed: 'declaration_confirmed',
-        date: 'declaration_date',
-        signature: 'declaration_signature',
+        date: 'declaration_date_demo',
       },
     },
   },
@@ -232,15 +314,20 @@ export function getSectionEndpointConfig(sectionId) {
   return BIODATA_SECTION_ENDPOINTS[sectionId] || null;
 }
 
-export function getSectionRepeatableEndpointConfig(sectionId, storageFieldName) {
-  return getSectionEndpointConfig(sectionId)?.repeatables?.[storageFieldName] || null;
+export function getSectionRepeatableEndpointConfig(
+  sectionId,
+  storageFieldName,
+) {
+  return (
+    getSectionEndpointConfig(sectionId)?.repeatables?.[storageFieldName] || null
+  );
 }
 
 export function getSectionFlatFieldNames(section) {
   const sectionEndpointConfig = getSectionEndpointConfig(section.id);
   const baseFieldNames = [
-    ...((section.fields || []).map(({ fieldName }) => fieldName)),
-    ...((section.fileFields || []).map(({ fieldName }) => fieldName)),
+    ...(section.fields || []).map(({ fieldName }) => fieldName),
+    ...(section.fileFields || []).map(({ fieldName }) => fieldName),
   ];
   const extraFieldNames = sectionEndpointConfig?.flat?.extraFieldNames || [];
 
@@ -250,42 +337,106 @@ export function getSectionFlatFieldNames(section) {
 export function getFlatUiToApiFieldMap(sectionId) {
   const fieldMap = getSectionEndpointConfig(sectionId)?.flat?.fieldMap || {};
 
-  return Object.entries(fieldMap).reduce((accumulator, [apiFieldName, uiFieldName]) => {
-    accumulator[uiFieldName] = apiFieldName;
-    return accumulator;
-  }, {});
+  return Object.entries(fieldMap).reduce(
+    (accumulator, [apiFieldName, uiFieldName]) => {
+      accumulator[uiFieldName] = apiFieldName;
+      return accumulator;
+    },
+    {},
+  );
 }
 
 export function getFlatApiToUiFieldMap(sectionId) {
   return getSectionEndpointConfig(sectionId)?.flat?.fieldMap || {};
 }
 
+export function sectionSupportsBackendSubmission(sectionId) {
+  return Boolean(
+    getSectionEndpointConfig(sectionId)?.flat?.submissionSupported,
+  );
+}
+
+export function repeatableSupportsBackendSubmission(
+  sectionId,
+  storageFieldName,
+) {
+  return Boolean(
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)
+      ?.submissionSupported,
+  );
+}
+
+export function getRepeatableFallbackNaFieldName(sectionId, storageFieldName) {
+  return (
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)
+      ?.fallbackNaFieldName || null
+  );
+}
+
 export function getRepeatableExtraFieldNames(sectionId, storageFieldName) {
-  return getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.extraFieldNames || [];
+  const endpointConfig = getSectionRepeatableEndpointConfig(
+    sectionId,
+    storageFieldName,
+  );
+
+  return [
+    ...Object.values(endpointConfig?.extraFieldMap || {}),
+    ...(endpointConfig?.extraFieldNames || []),
+    ...(!endpointConfig?.extraFieldMap && endpointConfig?.fallbackNaFieldName
+      ? [endpointConfig.fallbackNaFieldName]
+      : []),
+  ];
+}
+
+export function getRepeatableExtraUiToApiFieldMap(sectionId, storageFieldName) {
+  const extraFieldMap =
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)
+      ?.extraFieldMap || {};
+
+  return Object.entries(extraFieldMap).reduce(
+    (accumulator, [apiFieldName, uiFieldName]) => {
+      accumulator[uiFieldName] = apiFieldName;
+      return accumulator;
+    },
+    {},
+  );
 }
 
 export function getSectionRepeatableConfigs(section) {
-  return (section.repeatables || []).map((repeatable) => ({
-    repeatable,
-    endpoint: getSectionRepeatableEndpointConfig(section.id, repeatable.storageFieldName),
-  })).filter(({ endpoint }) => Boolean(endpoint));
+  return (section.repeatables || [])
+    .map((repeatable) => ({
+      repeatable,
+      endpoint: getSectionRepeatableEndpointConfig(
+        section.id,
+        repeatable.storageFieldName,
+      ),
+    }))
+    .filter(({ endpoint }) => Boolean(endpoint));
 }
 
 export function getRepeatableUiToApiFieldMap(sectionId, storageFieldName) {
-  const fieldMap = getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap || {};
+  const fieldMap =
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap ||
+    {};
 
-  return Object.entries(fieldMap).reduce((accumulator, [apiFieldName, uiFieldName]) => {
-    accumulator[uiFieldName] = apiFieldName;
-    return accumulator;
-  }, {});
+  return Object.entries(fieldMap).reduce(
+    (accumulator, [apiFieldName, uiFieldName]) => {
+      accumulator[uiFieldName] = apiFieldName;
+      return accumulator;
+    },
+    {},
+  );
 }
 
 export function getRepeatableApiToUiFieldMap(sectionId, storageFieldName) {
-  return getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap || {};
+  return (
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap ||
+    {}
+  );
 }
 
 export function getConfiguredBiodataSections() {
   return Object.keys(BIODATA_SECTION_ENDPOINTS)
-    .map(sectionId => BIODATA_SECTION_MAP[sectionId])
+    .map((sectionId) => BIODATA_SECTION_MAP[sectionId])
     .filter(Boolean);
 }

--- a/src/profile/biodata/apiConfig.js
+++ b/src/profile/biodata/apiConfig.js
@@ -389,9 +389,11 @@ export function getRepeatableExtraFieldNames(sectionId, storageFieldName) {
 }
 
 export function getRepeatableExtraUiToApiFieldMap(sectionId, storageFieldName) {
-  const extraFieldMap =
+  const extraFieldMap = (
     getSectionRepeatableEndpointConfig(sectionId, storageFieldName)
-      ?.extraFieldMap || {};
+      ?.extraFieldMap
+    || {}
+  );
 
   return Object.entries(extraFieldMap).reduce(
     (accumulator, [apiFieldName, uiFieldName]) => {
@@ -415,9 +417,10 @@ export function getSectionRepeatableConfigs(section) {
 }
 
 export function getRepeatableUiToApiFieldMap(sectionId, storageFieldName) {
-  const fieldMap =
-    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap ||
-    {};
+  const fieldMap = (
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap
+    || {}
+  );
 
   return Object.entries(fieldMap).reduce(
     (accumulator, [apiFieldName, uiFieldName]) => {
@@ -430,8 +433,8 @@ export function getRepeatableUiToApiFieldMap(sectionId, storageFieldName) {
 
 export function getRepeatableApiToUiFieldMap(sectionId, storageFieldName) {
   return (
-    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap ||
-    {}
+    getSectionRepeatableEndpointConfig(sectionId, storageFieldName)?.fieldMap
+    || {}
   );
 }
 

--- a/src/profile/biodata/apiTransforms.js
+++ b/src/profile/biodata/apiTransforms.js
@@ -2,11 +2,13 @@ import {
   getConfiguredBiodataSections,
   getFlatUiToApiFieldMap,
   getRepeatableExtraFieldNames,
+  getRepeatableExtraUiToApiFieldMap,
   getFlatApiToUiFieldMap,
   getRepeatableApiToUiFieldMap,
   getRepeatableUiToApiFieldMap,
   getSectionFlatFieldNames,
   getSectionRepeatableConfigs,
+  sectionSupportsBackendSubmission,
 } from './apiConfig';
 import {
   PROFILE_FIELD_TYPES,
@@ -14,16 +16,64 @@ import {
 } from './config';
 import {
   createEmptyRepeatableRow,
+  getFileUploadBlob,
   getSanitizedSectionData,
+  getSectionSubmittedFieldName,
   isSingleMaritalStatus,
+  normalizeRepeatableRows,
 } from './utils';
 
-const FILE_FIELD_KEYS = ['name', 'dataUrl', 'url', 'imageUrl', 'previewUrl'];
+const FILE_FIELD_KEYS = ['name', 'type', 'size', 'file', 'url', 'imageUrl', 'previewUrl'];
 const YES_NO_FIELD_NAMES = [
   'applied_for_forthcoming_css_exam',
   'intend_to_sit_for_forthcoming_css_exam',
   'other_income_source_besides_salary',
+  'is_first_job',
 ];
+const CSS_EXAM_DETAILS_SECTION_ID = 'cssExamDetails';
+const CSS_SERVICE_PREFERENCES_API_FIELD = 'service_preferences';
+const CSS_SERVICE_PREFERENCES_UI_FIELD = 'occupational_service_group_preferences';
+const DEMO_NOT_APPLICABLE_FIELD = 'not_applicable_demo';
+const BACKEND_NOT_APPLICABLE_FIELD = 'not_applicable';
+const BACKEND_IS_SUBMITTED_FIELD = 'is_submitted';
+
+function humanizeFieldName(fieldName) {
+  return String(fieldName || '')
+    .replace(/_/g, ' ')
+    .replace(/\b\w/g, letter => letter.toUpperCase());
+}
+
+function friendlyValidationMessage(message, fieldName = '') {
+  const normalizedMessage = String(message || '').trim();
+  const lowerMessage = normalizedMessage.toLowerCase();
+  const fieldLabel = humanizeFieldName(fieldName);
+
+  if (!normalizedMessage) {
+    return fieldLabel ? `Please check ${fieldLabel}.` : 'Please check this field.';
+  }
+
+  if (lowerMessage.includes('date has wrong format')) {
+    return 'Enter a valid date in YYYY-MM-DD format.';
+  }
+
+  if (lowerMessage.includes('this field is required') || lowerMessage === 'required') {
+    return fieldLabel ? `${fieldLabel} is required.` : 'This field is required.';
+  }
+
+  if (lowerMessage.includes('valid cnic')) {
+    return 'Enter a valid 13-digit CNIC number.';
+  }
+
+  if (lowerMessage.includes('cannot exceed total marks')) {
+    return 'Marks obtained cannot be greater than total marks.';
+  }
+
+  if (lowerMessage.includes('enter a valid')) {
+    return normalizedMessage;
+  }
+
+  return normalizedMessage;
+}
 
 function normalizeMessage(errorValue) {
   if (Array.isArray(errorValue)) {
@@ -52,13 +102,16 @@ function normalizeMessage(errorValue) {
   return 'Unable to save this section.';
 }
 
-function normalizeFieldError(errorValue) {
+function normalizeFieldError(errorValue, fieldName = '') {
   if (errorValue && typeof errorValue === 'object' && typeof errorValue.userMessage === 'string') {
-    return errorValue;
+    return {
+      ...errorValue,
+      userMessage: friendlyValidationMessage(errorValue.userMessage, fieldName),
+    };
   }
 
   return {
-    userMessage: normalizeMessage(errorValue),
+    userMessage: friendlyValidationMessage(normalizeMessage(errorValue), fieldName),
   };
 }
 
@@ -91,6 +144,17 @@ function normalizeFileValue(value) {
   }
 
   if (typeof value === 'object') {
+    const file = getFileUploadBlob(value);
+    if (file) {
+      return {
+        ...value,
+        file,
+        name: value.name || file.name,
+        type: value.type || file.type,
+        size: value.size || file.size,
+      };
+    }
+
     const normalizedValue = {};
     FILE_FIELD_KEYS.forEach((key) => {
       if (value[key]) {
@@ -110,9 +174,61 @@ function normalizeFileValue(value) {
   return null;
 }
 
+function normalizeCssServicePreferenceRows(value) {
+  const rows = (() => {
+    if (Array.isArray(value)) {
+      return value;
+    }
+
+    if (typeof value === 'string' && value.trim().length > 0) {
+      try {
+        const parsed = JSON.parse(value);
+        return Array.isArray(parsed) ? parsed : [];
+      } catch (error) {
+        return value.split('\n').filter(Boolean).map((item, index) => ({
+          value: item,
+          preference: index + 1,
+        }));
+      }
+    }
+
+    return [];
+  })();
+
+  return rows.map((row, index) => {
+    const serviceGroup = row?.value
+      ?? row?.service_group
+      ?? row?.service_group_preference
+      ?? row?.label
+      ?? row?.name
+      ?? row?.group
+      ?? '';
+
+    return {
+      service_group_preference: serviceGroup == null ? '' : String(serviceGroup),
+      priority: String(index + 1),
+      ...(row?.id != null ? { backendId: row.id } : {}),
+      ...(row?.backendId != null ? { backendId: row.backendId } : {}),
+    };
+  });
+}
+
+function getMappedFlatValue(section, flatResponse, fieldName) {
+  const uiToApiFieldMap = getFlatUiToApiFieldMap(section.id);
+  const flatApiToUiFieldMap = getFlatApiToUiFieldMap(section.id);
+
+  return flatResponse[uiToApiFieldMap[fieldName] || fieldName]
+    ?? flatResponse[flatApiToUiFieldMap[fieldName] || fieldName];
+}
+
 function normalizeRepeatableRow(row, repeatable, uiToApiFieldMap = {}) {
   const normalizedRow = repeatable.columns.reduce((accumulator, column) => {
     const apiFieldName = uiToApiFieldMap[column.key] || column.key;
+    if (column.type === PROFILE_FIELD_TYPES.FILE) {
+      accumulator[column.key] = normalizeFileValue(row?.[apiFieldName]);
+      return accumulator;
+    }
+
     accumulator[column.key] = row?.[apiFieldName] == null ? '' : String(row[apiFieldName]);
     return accumulator;
   }, {});
@@ -180,6 +296,16 @@ function normalizeFlatPayloadValue(fieldName, value) {
   return value;
 }
 
+function mapRepeatableExtraFieldsToPayload(sectionId, storageFieldName, extraFields = {}) {
+  const extraUiToApiFieldMap = getRepeatableExtraUiToApiFieldMap(sectionId, storageFieldName);
+
+  return Object.entries(extraFields).reduce((accumulator, [fieldName, value]) => {
+    const apiFieldName = extraUiToApiFieldMap[fieldName] || fieldName;
+    accumulator[apiFieldName] = normalizeFlatPayloadValue(fieldName, value);
+    return accumulator;
+  }, {});
+}
+
 export function normalizeBiodataErrorForSection(error, sectionId = null) {
   const processedError = Object.create(error);
   const errorData = error?.response?.data;
@@ -198,10 +324,13 @@ export function normalizeBiodataErrorForSection(error, sectionId = null) {
 
   const normalizedFieldErrors = Object.entries(extractErrorMap(errorData)).reduce((accumulator, [fieldName, value]) => {
     accumulator[
-      flatApiToUiFieldMap[fieldName]
+      (sectionId === CSS_EXAM_DETAILS_SECTION_ID && fieldName === CSS_SERVICE_PREFERENCES_API_FIELD
+        ? CSS_SERVICE_PREFERENCES_UI_FIELD
+        : null)
+      || flatApiToUiFieldMap[fieldName]
       || repeatableApiToUiFieldMaps[fieldName]
       || fieldName
-    ] = normalizeFieldError(value);
+    ] = normalizeFieldError(value, fieldName);
     return accumulator;
   }, {});
 
@@ -218,17 +347,55 @@ export function normalizeBiodataError(error) {
 
 function buildSectionEntries(section, flatResponse = {}, repeatableResponsesByKey = {}) {
   const flatFieldNames = getSectionFlatFieldNames(section);
-  const flatApiToUiFieldMap = getFlatApiToUiFieldMap(section.id);
-  const flatEntries = flatFieldNames.map((fieldName) => ({
-    fieldName,
-    fieldValue: coerceFlatFieldValue(
-      section,
-      fieldName,
-      flatResponse[getFlatUiToApiFieldMap(section.id)[fieldName] || fieldName]
-        ?? flatResponse[flatApiToUiFieldMap[fieldName] || fieldName],
-    ),
-  }));
+  const flatEntries = flatFieldNames.map((fieldName) => {
+    const rawValue = getMappedFlatValue(section, flatResponse, fieldName);
+    const shouldDeferEmploymentChoice = section.id === 'employment'
+      && fieldName === 'is_first_job'
+      && rawValue === false
+      && flatResponse[BACKEND_IS_SUBMITTED_FIELD] !== true;
 
+    return {
+      fieldName,
+      fieldValue: shouldDeferEmploymentChoice ? '' : coerceFlatFieldValue(
+        section,
+        fieldName,
+        rawValue,
+      ),
+    };
+  });
+  const sectionNaEntries = section.naFieldName
+    ? [{
+      fieldName: section.naFieldName,
+      fieldValue: Boolean(
+        getMappedFlatValue(section, flatResponse, section.naFieldName)
+        ?? flatResponse[BACKEND_NOT_APPLICABLE_FIELD]
+        ?? flatResponse[DEMO_NOT_APPLICABLE_FIELD]
+        ?? false,
+      ),
+    }]
+    : [];
+  const submittedFieldName = getSectionSubmittedFieldName(section.id);
+  const submissionEntries = (
+    sectionSupportsBackendSubmission(section.id)
+    || flatResponse[submittedFieldName] !== undefined
+    || flatResponse[BACKEND_IS_SUBMITTED_FIELD] !== undefined
+  )
+    ? [{
+      fieldName: submittedFieldName,
+      fieldValue: Boolean(flatResponse[submittedFieldName] ?? flatResponse[BACKEND_IS_SUBMITTED_FIELD]),
+    }]
+    : [];
+
+  const configuredRepeatableStorageFieldNames = new Set(
+    getSectionRepeatableConfigs(section).map(({ repeatable }) => repeatable.storageFieldName),
+  );
+  const embeddedRepeatableEntries = section.id === CSS_EXAM_DETAILS_SECTION_ID
+    && !configuredRepeatableStorageFieldNames.has(CSS_SERVICE_PREFERENCES_UI_FIELD)
+    ? [{
+      fieldName: CSS_SERVICE_PREFERENCES_UI_FIELD,
+      fieldValue: normalizeCssServicePreferenceRows(flatResponse[CSS_SERVICE_PREFERENCES_API_FIELD]),
+    }]
+    : [];
   const repeatableEntries = getSectionRepeatableConfigs(section).map(({ repeatable }) => {
     const uiToApiFieldMap = getRepeatableUiToApiFieldMap(section.id, repeatable.storageFieldName);
 
@@ -238,6 +405,16 @@ function buildSectionEntries(section, flatResponse = {}, repeatableResponsesByKe
         .map(row => normalizeRepeatableRow(row, repeatable, uiToApiFieldMap)),
     };
   });
+  const localRepeatableEntries = (section.repeatables || [])
+    .filter(repeatable => !configuredRepeatableStorageFieldNames.has(repeatable.storageFieldName))
+    .filter(repeatable => (
+      section.id !== CSS_EXAM_DETAILS_SECTION_ID
+      || repeatable.storageFieldName !== CSS_SERVICE_PREFERENCES_UI_FIELD
+    ))
+    .map(repeatable => ({
+      fieldName: repeatable.storageFieldName,
+      fieldValue: [],
+    }));
 
   const repeatableExtraEntries = getSectionRepeatableConfigs(section)
     .flatMap(({ repeatable }) => getRepeatableExtraFieldNames(section.id, repeatable.storageFieldName)
@@ -245,8 +422,23 @@ function buildSectionEntries(section, flatResponse = {}, repeatableResponsesByKe
         fieldName,
         fieldValue: Boolean(flatResponse[fieldName] ?? false),
       })));
+  const repeatableNaEntries = (section.repeatables || [])
+    .filter(repeatable => repeatable.naFieldName)
+    .map(repeatable => ({
+      fieldName: repeatable.naFieldName,
+      fieldValue: Boolean(flatResponse[repeatable.naFieldName] ?? false),
+    }));
 
-  return [...flatEntries, ...repeatableEntries, ...repeatableExtraEntries];
+  return [
+    ...sectionNaEntries,
+    ...submissionEntries,
+    ...flatEntries,
+    ...embeddedRepeatableEntries,
+    ...repeatableEntries,
+    ...localRepeatableEntries,
+    ...repeatableExtraEntries,
+    ...repeatableNaEntries,
+  ];
 }
 
 function getSectionFieldNames(section) {
@@ -289,38 +481,95 @@ export function mapSectionDataToFlatPayload(section, sectionData) {
   const fieldNames = getSectionFlatFieldNames(section);
   const flatUiToApiFieldMap = getFlatUiToApiFieldMap(section.id);
 
-  return fieldNames.reduce((accumulator, fieldName) => {
+  const payload = fieldNames.reduce((accumulator, fieldName) => {
     if (sanitizedData[fieldName] === undefined) {
       return accumulator;
     }
 
+    const field = [
+      ...(section.fields || []),
+      ...(section.fileFields || []),
+    ].find(item => item.fieldName === fieldName);
     const apiFieldName = flatUiToApiFieldMap[fieldName] || fieldName;
+    if (field && section.fileFields?.some(item => item.fieldName === fieldName)) {
+      if (getFileUploadBlob(sanitizedData[fieldName])) {
+        accumulator[apiFieldName] = normalizeFileValue(sanitizedData[fieldName]);
+      }
+      return accumulator;
+    }
+
     accumulator[apiFieldName] = normalizeFlatPayloadValue(fieldName, sanitizedData[fieldName]);
     return accumulator;
   }, {});
+
+  if (section.naFieldName) {
+    const apiFieldName = flatUiToApiFieldMap[section.naFieldName]
+      || BACKEND_NOT_APPLICABLE_FIELD;
+
+    payload[apiFieldName] = Boolean(sanitizedData[section.naFieldName]);
+  }
+
+  if (section.id === 'employment') {
+    payload[BACKEND_NOT_APPLICABLE_FIELD] = sanitizedData.is_first_job === 'Yes';
+  }
+
+  return payload;
 }
 
 export function mapSectionDataToRepeatablePayloads(section, sectionData) {
   const sanitizedData = getSanitizedSectionData(section, sectionData);
 
-  return getSectionRepeatableConfigs(section).map(({ repeatable, endpoint }) => ({
-    repeatable,
-    endpoint,
-    extraFields: pickDefinedFields(
-      sanitizedData,
-      getRepeatableExtraFieldNames(section.id, repeatable.storageFieldName),
-    ),
-    rows: (sanitizedData[repeatable.storageFieldName] || [])
-      .filter((row) => repeatable.columns.some(({ key }) => String(row?.[key] || '').trim().length > 0))
+  return getSectionRepeatableConfigs(section).filter(({ endpoint }) => {
+    const skipRule = endpoint.skipWhenFieldEquals;
+
+    return !skipRule || sanitizedData[skipRule.fieldName] !== skipRule.value;
+  }).map(({ repeatable, endpoint }) => {
+    const extraFields = mapRepeatableExtraFieldsToPayload(
+      section.id,
+      repeatable.storageFieldName,
+      pickDefinedFields(
+        sanitizedData,
+        getRepeatableExtraFieldNames(section.id, repeatable.storageFieldName),
+      ),
+    );
+    const rows = (sanitizedData[repeatable.storageFieldName] || [])
+      .filter((row) => repeatable.columns.some(({ key, type }) => (
+        type === PROFILE_FIELD_TYPES.FILE
+          ? Boolean(row?.[key])
+          : String(row?.[key] || '').trim().length > 0
+      )))
       .map((row) => ({
         backendId: row.backendId ?? row.id ?? null,
-        values: repeatable.columns.reduce((accumulator, { key }) => {
+        values: repeatable.columns.reduce((accumulator, { key, type }) => {
           const apiFieldName = getRepeatableUiToApiFieldMap(section.id, repeatable.storageFieldName)[key] || key;
+          if (type === PROFILE_FIELD_TYPES.FILE) {
+            if (getFileUploadBlob(row?.[key])) {
+              accumulator[apiFieldName] = normalizeFileValue(row?.[key]);
+            }
+            return accumulator;
+          }
+
           accumulator[apiFieldName] = row?.[key] ?? '';
           return accumulator;
         }, {}),
-      })),
-  }));
+      }));
+    const shouldMergeExtraFieldsIntoRows = endpoint.mergeExtraFieldsIntoRows && rows.length > 0;
+
+    return {
+      repeatable,
+      endpoint,
+      extraFields: shouldMergeExtraFieldsIntoRows ? {} : extraFields,
+      rows: shouldMergeExtraFieldsIntoRows
+        ? rows.map(row => ({
+          ...row,
+          values: {
+            ...extraFields,
+            ...row.values,
+          },
+        }))
+        : rows,
+    };
+  });
 }
 
 export function buildSectionDraftFromExtendedProfile(sectionId, extendedProfile) {
@@ -352,10 +601,18 @@ export function buildSectionDraftFromExtendedProfile(sectionId, extendedProfile)
     const rows = Array.isArray(fieldMap[repeatable.storageFieldName])
       ? fieldMap[repeatable.storageFieldName].map(row => normalizeRepeatableRow(row, repeatable, uiToApiFieldMap))
       : [];
+    const defaultRows = repeatable.defaultRows || [];
+    let draftRows = rows;
 
-    accumulator[repeatable.storageFieldName] = rows.length > 0
-      ? rows
-      : [createEmptyRepeatableRow(repeatable)];
+    if (draftRows.length === 0 && defaultRows.length > 0) {
+      draftRows = defaultRows.map(row => createEmptyRepeatableRow({ ...repeatable, emptyRow: row }));
+    }
+
+    if (draftRows.length === 0) {
+      draftRows = [createEmptyRepeatableRow(repeatable)];
+    }
+
+    accumulator[repeatable.storageFieldName] = normalizeRepeatableRows(draftRows, repeatable);
 
     if (repeatable.naFieldName) {
       accumulator[repeatable.naFieldName] = Boolean(fieldMap[repeatable.naFieldName]);

--- a/src/profile/biodata/config.js
+++ b/src/profile/biodata/config.js
@@ -271,7 +271,9 @@ export const BIODATA_SECTIONS = [
         columns: [
           { key: 'examination_name', label: 'Examination name', placeholder: 'Enter examination name' },
           { key: 'agency_holding_examination', label: 'Agency holding examination', placeholder: 'Enter agency name' },
-          { key: 'year', label: 'Year', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter year' },
+          {
+            key: 'year', label: 'Year', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter year',
+          },
           {
             key: 'result_details', label: 'Result details', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter result details',
           },
@@ -338,7 +340,9 @@ export const BIODATA_SECTIONS = [
         },
         columns: [
           { key: 'subject', label: 'Subject', placeholder: 'Enter subject' },
-          { key: 'total_marks', label: 'Total Marks', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter total marks' },
+          {
+            key: 'total_marks', label: 'Total Marks', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter total marks',
+          },
           {
             key: 'marks_obtained',
             label: 'Marks Obtained',

--- a/src/profile/biodata/config.js
+++ b/src/profile/biodata/config.js
@@ -5,6 +5,7 @@ export const PROFILE_FIELD_TYPES = {
   TEXTAREA: 'textarea',
   SELECT: 'select',
   CHECKBOX: 'checkbox',
+  FILE: 'file',
 };
 
 const YES_NO_OPTIONS = [
@@ -37,6 +38,16 @@ const PROFICIENCY_OPTIONS = [
   { value: 'native', label: 'Native' },
 ];
 
+export const CSS_COMPULSORY_SUBJECT_MARKS = [
+  { subject: 'English Essay', total_marks: '100', marks_obtained: '' },
+  { subject: 'English Precise & Composition', total_marks: '100', marks_obtained: '' },
+  { subject: 'General Science & Ability', total_marks: '100', marks_obtained: '' },
+  { subject: 'Current Affairs', total_marks: '100', marks_obtained: '' },
+  { subject: 'Pakistan Affairs', total_marks: '100', marks_obtained: '' },
+  { subject: 'Islamic Studies', total_marks: '100', marks_obtained: '' },
+  { subject: 'Viva Voce', total_marks: '300', marks_obtained: '' },
+];
+
 export const BIODATA_SECTIONS = [
   {
     id: 'basicInformation',
@@ -66,6 +77,23 @@ export const BIODATA_SECTIONS = [
         fieldName: 'daughters', label: 'Daughters', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
       },
     ],
+    fileFields: [
+      {
+        fieldName: 'cnic_front',
+        label: 'CNIC Front',
+        accept: '.jpg,.jpeg,.png,.webp,.pdf',
+      },
+      {
+        fieldName: 'cnic_back',
+        label: 'CNIC Back',
+        accept: '.jpg,.jpeg,.png,.webp,.pdf',
+      },
+      {
+        fieldName: 'domicile_file',
+        label: 'Domicile Attachment',
+        accept: '.jpg,.jpeg,.png,.webp,.pdf',
+      },
+    ],
   },
   {
     id: 'physicalMedicalInformation',
@@ -73,8 +101,12 @@ export const BIODATA_SECTIONS = [
     helperText: 'Medical checkup date and physical details.',
     fields: [
       { fieldName: 'last_annual_medical_checkup', label: 'Date of last annual medical checkup', type: PROFILE_FIELD_TYPES.DATE },
-      { fieldName: 'height', label: 'Height', placeholder: 'Enter height' },
-      { fieldName: 'weight', label: 'Weight', placeholder: 'Enter weight' },
+      {
+        fieldName: 'height', label: 'Height (Inches)', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter height in inches',
+      },
+      {
+        fieldName: 'weight', label: 'Weight (kg)', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter weight in kg',
+      },
     ],
   },
   {
@@ -101,12 +133,13 @@ export const BIODATA_SECTIONS = [
   {
     id: 'education',
     title: 'Education',
-    helperText: 'Academic record in repeatable rows.',
+    helperText: 'Academic records are shown in reverse order.',
     repeatables: [
       {
         storageFieldName: 'education_records',
         addButtonLabel: 'Add education record',
         itemLabel: 'Education record',
+        showRowNumber: false,
         emptyRow: {
           educational_institute: '',
           attended_from: '',
@@ -115,6 +148,7 @@ export const BIODATA_SECTIONS = [
           year_of_passing: '',
           grade_division: '',
           subjects_studied: '',
+          education_degree_attachment: null,
         },
         columns: [
           { key: 'educational_institute', label: 'Educational Institute', placeholder: 'Enter educational institute' },
@@ -125,6 +159,12 @@ export const BIODATA_SECTIONS = [
           { key: 'grade_division', label: 'Grade / Division', placeholder: 'Enter grade or division' },
           {
             key: 'subjects_studied', label: 'Subjects Studied', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter subjects studied',
+          },
+          {
+            key: 'education_degree_attachment',
+            label: 'Education Degree Attachment',
+            type: PROFILE_FIELD_TYPES.FILE,
+            accept: '.jpg,.jpeg,.png,.webp,.pdf',
           },
         ],
       },
@@ -181,10 +221,11 @@ export const BIODATA_SECTIONS = [
   {
     id: 'employment',
     title: 'Employment',
-    helperText: 'Employment gap details and record.',
-    naFieldName: 'employment_not_applicable',
-    naLabel: 'N/A',
+    helperText: 'First-job status, employment gap details, and employment record.',
     fields: [
+      {
+        fieldName: 'is_first_job', label: 'Is this your first job?', type: PROFILE_FIELD_TYPES.SELECT, options: YES_NO_OPTIONS,
+      },
       {
         fieldName: 'first_employment_gap_details_after_education', label: 'First employment gap details after education', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter employment gap details',
       },
@@ -230,7 +271,7 @@ export const BIODATA_SECTIONS = [
         columns: [
           { key: 'examination_name', label: 'Examination name', placeholder: 'Enter examination name' },
           { key: 'agency_holding_examination', label: 'Agency holding examination', placeholder: 'Enter agency name' },
-          { key: 'year', label: 'Year', placeholder: 'Enter year' },
+          { key: 'year', label: 'Year', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter year' },
           {
             key: 'result_details', label: 'Result details', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter result details',
           },
@@ -247,9 +288,6 @@ export const BIODATA_SECTIONS = [
       { fieldName: 'css_roll_number', label: 'CSS Roll Number', placeholder: 'Enter CSS roll number' },
       { fieldName: 'css_merit_position', label: 'CSS Merit Position', placeholder: 'Enter CSS merit position' },
       {
-        fieldName: 'occupational_service_group_preferences', label: 'Occupational / Service Group Preferences', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter occupational or service group preferences',
-      },
-      {
         fieldName: 'css_chances_availed', label: 'CSS chances availed', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: '0',
       },
       {
@@ -262,9 +300,37 @@ export const BIODATA_SECTIONS = [
     ],
     repeatables: [
       {
+        storageFieldName: 'occupational_service_group_preferences',
+        addButtonLabel: 'Add service group preference',
+        itemLabel: 'Service group preference',
+        autoPriorityKey: 'priority',
+        emptyRow: {
+          service_group: '',
+          priority: '',
+        },
+        columns: [
+          {
+            key: 'service_group',
+            label: 'Service group preference',
+            placeholder: 'Enter service group preference',
+          },
+          {
+            key: 'priority',
+            label: 'Priority',
+            type: PROFILE_FIELD_TYPES.NUMBER,
+            placeholder: '1',
+            displayOnly: true,
+          },
+        ],
+      },
+      {
         storageFieldName: 'css_subject_marks',
         addButtonLabel: 'Add subject mark',
         itemLabel: 'Subject mark',
+        defaultRows: CSS_COMPULSORY_SUBJECT_MARKS,
+        protectedRows: CSS_COMPULSORY_SUBJECT_MARKS,
+        protectedRowKey: 'subject',
+        protectedColumns: ['subject', 'total_marks'],
         emptyRow: {
           subject: '',
           total_marks: '',
@@ -272,9 +338,27 @@ export const BIODATA_SECTIONS = [
         },
         columns: [
           { key: 'subject', label: 'Subject', placeholder: 'Enter subject' },
-          { key: 'total_marks', label: 'Total Marks', placeholder: 'Enter total marks' },
-          { key: 'marks_obtained', label: 'Marks Obtained', placeholder: 'Enter marks obtained' },
+          { key: 'total_marks', label: 'Total Marks', type: PROFILE_FIELD_TYPES.NUMBER, placeholder: 'Enter total marks' },
+          {
+            key: 'marks_obtained',
+            label: 'Marks Obtained',
+            type: PROFILE_FIELD_TYPES.NUMBER,
+            placeholder: 'Enter marks obtained',
+            validate: (value, row) => {
+              if (row.total_marks !== '' && Number(value) > Number(row.total_marks)) {
+                return 'Marks obtained cannot exceed total marks.';
+              }
+              return '';
+            },
+          },
         ],
+      },
+    ],
+    fileFields: [
+      {
+        fieldName: 'css_marksheet_attachment',
+        label: 'CSS Mark Sheet Attachment',
+        accept: '.jpg,.jpeg,.png,.webp,.pdf',
       },
     ],
   },
@@ -342,28 +426,35 @@ export const BIODATA_SECTIONS = [
   {
     id: 'familyInformation',
     title: 'Family Information',
-    helperText: 'Parents and siblings details.',
+    helperText: 'Parents details.',
     fields: [
       { fieldName: 'father_name', label: 'Father Name', placeholder: 'Enter father name' },
       { fieldName: 'father_education', label: 'Father Education', placeholder: 'Enter father education' },
       { fieldName: 'father_occupation', label: 'Father Occupation', placeholder: 'Enter father occupation' },
       {
-        fieldName: 'father_address_phone_number', label: 'Father Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter father address and phone number',
+        fieldName: 'father_address', label: 'Father Address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter father address',
       },
+      { fieldName: 'father_phone_number', label: 'Father Phone Number', placeholder: 'Enter father phone number' },
       { fieldName: 'mother_name', label: 'Mother Name', placeholder: 'Enter mother name' },
       { fieldName: 'mother_education', label: 'Mother Education', placeholder: 'Enter mother education' },
       { fieldName: 'mother_occupation', label: 'Mother Occupation', placeholder: 'Enter mother occupation' },
       {
-        fieldName: 'mother_address_phone_number', label: 'Mother Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter mother address and phone number',
+        fieldName: 'mother_address', label: 'Mother Address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter mother address',
       },
+      { fieldName: 'mother_phone_number', label: 'Mother Phone Number', placeholder: 'Enter mother phone number' },
     ],
+  },
+  {
+    id: 'siblings',
+    title: 'Siblings',
+    helperText: 'Brother and sister details.',
+    naFieldName: 'siblings_not_applicable',
+    naLabel: 'N/A',
     repeatables: [
       {
         storageFieldName: 'siblings_family_information',
         addButtonLabel: 'Add family member',
         itemLabel: 'Brother / Sister',
-        naFieldName: 'siblings_not_applicable',
-        naLabel: 'N/A',
         emptyRow: {
           relationship: '',
           name: '',
@@ -372,7 +463,16 @@ export const BIODATA_SECTIONS = [
           address: '',
         },
         columns: [
-          { key: 'relationship', label: 'Relationship', placeholder: 'Enter brother or sister' },
+          {
+            key: 'relationship',
+            label: 'Relationship',
+            type: PROFILE_FIELD_TYPES.SELECT,
+            options: [
+              { value: '', label: 'Select relationship' },
+              { value: 'brother', label: 'Brother' },
+              { value: 'sister', label: 'Sister' },
+            ],
+          },
           { key: 'name', label: 'Name', placeholder: 'Enter name' },
           { key: 'education', label: 'Education', placeholder: 'Enter education' },
           { key: 'occupation', label: 'Occupation', placeholder: 'Enter occupation' },
@@ -420,24 +520,17 @@ export const BIODATA_SECTIONS = [
       { fieldName: 'spouse_education', label: 'Spouse Education', placeholder: 'Enter spouse education' },
       { fieldName: 'spouse_occupation', label: 'Spouse Occupation', placeholder: 'Enter spouse occupation' },
       {
-        fieldName: 'spouse_address_phone_number', label: 'Spouse Address & Phone Number', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter spouse address and phone number',
+        fieldName: 'spouse_address', label: 'Spouse Address', type: PROFILE_FIELD_TYPES.TEXTAREA, placeholder: 'Enter spouse address',
       },
+      { fieldName: 'spouse_phone', label: 'Spouse Phone', placeholder: 'Enter spouse phone' },
     ],
   },
   {
     id: 'declaration',
     title: 'Declaration',
-    helperText: 'Confirm the information and add a signature image if needed.',
+    helperText: 'Confirm the information before submitting.',
     fields: [
       { fieldName: 'declaration_confirmed', label: 'I confirm that the information provided is correct.', type: PROFILE_FIELD_TYPES.CHECKBOX },
-      { fieldName: 'declaration_date', label: 'Date', type: PROFILE_FIELD_TYPES.DATE },
-    ],
-    fileFields: [
-      {
-        fieldName: 'declaration_signature',
-        label: 'Signature',
-        accept: '.jpg,.jpeg,.png,.webp',
-      },
     ],
   },
 ];

--- a/src/profile/biodata/utils.js
+++ b/src/profile/biodata/utils.js
@@ -1,3 +1,5 @@
+import { getConfig } from '@edx/frontend-platform';
+
 import { BIODATA_SECTION_MAP, PROFILE_FIELD_TYPES } from './config';
 
 let repeatableRowCounter = 0;
@@ -6,11 +8,299 @@ const SPOUSE_FIELD_NAMES = [
   'spouse_name',
   'spouse_education',
   'spouse_occupation',
-  'spouse_address_phone_number',
+  'spouse_address',
+  'spouse_phone',
 ];
+const EMPLOYMENT_SECTION_ID = 'employment';
+const EMPLOYMENT_RECORDS_FIELD_NAME = 'employment_records';
+const FIRST_JOB_FIELD_NAME = 'is_first_job';
+const FIRST_JOB_GAP_FIELD_NAME = 'first_employment_gap_details_after_education';
+const CSS_EXAM_DETAILS_SECTION_ID = 'cssExamDetails';
+const CSS_SERVICE_PREFERENCES_FIELD_NAME = 'occupational_service_group_preferences';
+const CSS_SUBJECT_MARKS_FIELD_NAME = 'css_subject_marks';
+const EDUCATION_SECTION_ID = 'education';
+const EDUCATION_RECORDS_FIELD_NAME = 'education_records';
+const FOREIGN_VISITS_SECTION_ID = 'foreignVisits';
+const FOREIGN_VISITS_FIELD_NAME = 'foreign_visits';
+const GOVERNMENT_SERVICE_DETAILS_SECTION_ID = 'governmentServiceDetails';
+const OTHER_INCOME_SOURCE_FIELD_NAME = 'other_income_source_besides_salary';
+const OTHER_INCOME_DETAILS_FIELD_NAME = 'other_income_details';
+const EDUCATION_ATTENDED_TO_DATE_MESSAGE = 'Attended To must be later than Attended From.';
+const EDUCATION_YEAR_OF_PASSING_MESSAGE = 'Year of Passing must be the same as the Attended To year.';
+const FOREIGN_VISIT_TO_DATE_MESSAGE = 'To date must be on or after From date.';
+const EMPLOYMENT_TO_DATE_MESSAGE = 'To date must be on or after From date.';
+export const BIODATA_DATE_VALIDATION_MESSAGES = [
+  EDUCATION_ATTENDED_TO_DATE_MESSAGE,
+  EDUCATION_YEAR_OF_PASSING_MESSAGE,
+  FOREIGN_VISIT_TO_DATE_MESSAGE,
+  EMPLOYMENT_TO_DATE_MESSAGE,
+];
+const DATE_FORMAT = /^\d{4}-\d{2}-\d{2}$/;
+const EMAIL_FORMAT = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const CNIC_FORMAT = /^\d{13}$/;
+const PAKISTAN_MOBILE_FORMAT = /^(?:\+92|92|0)3[0-9]{9}$/;
+const PAKISTAN_MOBILE_VALIDATION_MESSAGE = 'Enter a valid Pakistan mobile number, e.g. +923001234567.';
+const PAKISTAN_MOBILE_FIELD_NAMES = [
+  'permanent_phone_number',
+  'present_phone_number',
+  'lahore_phone_number',
+  'mobile_number',
+  'father_phone_number',
+  'mother_phone_number',
+  'spouse_phone',
+];
+const CONDITIONAL_FILE_FIELD_DEPENDENCIES = {
+  cnic_front: 'identity_card_number',
+  cnic_back: 'identity_card_number',
+  domicile_file: 'district_of_domicile',
+};
+
+export function getSectionSubmittedFieldName(sectionId) {
+  return `${sectionId}_is_submitted`;
+}
+
+export function isBrowserFile(value) {
+  return typeof File !== 'undefined' && value instanceof File;
+}
+
+export function getFileUploadBlob(fileValue) {
+  if (isBrowserFile(fileValue)) {
+    return fileValue;
+  }
+
+  if (isBrowserFile(fileValue?.file)) {
+    return fileValue.file;
+  }
+
+  return null;
+}
+
+export function createFileUploadValue(file) {
+  if (!file) {
+    return null;
+  }
+
+  return {
+    name: file.name,
+    type: file.type,
+    size: file.size,
+    file,
+    previewUrl: typeof URL !== 'undefined' && URL.createObjectURL
+      ? URL.createObjectURL(file)
+      : null,
+  };
+}
+
+function getFileExtension(value) {
+  const normalizedValue = String(value || '').split(/[?#]/)[0].trim();
+  const extensionMatch = normalizedValue.match(/\.([a-z0-9]+)$/i);
+  return extensionMatch ? extensionMatch[1].toLowerCase() : '';
+}
+
+function getFileNameFromUrl(url) {
+  const filename = String(url || '').split(/[?#]/)[0].split('/').pop();
+  if (!filename) {
+    return 'file';
+  }
+
+  try {
+    return decodeURIComponent(filename);
+  } catch (error) {
+    return filename;
+  }
+}
+
+function getLmsBaseUrl() {
+  try {
+    return getConfig().LMS_BASE_URL || '';
+  } catch (error) {
+    return '';
+  }
+}
+
+function resolveFilePreviewUrl(url) {
+  const normalizedUrl = String(url || '').trim();
+
+  if (!normalizedUrl) {
+    return '';
+  }
+
+  if (/^(https?:|blob:|data:)/i.test(normalizedUrl)) {
+    return normalizedUrl;
+  }
+
+  const lmsBaseUrl = getLmsBaseUrl();
+  if (!lmsBaseUrl) {
+    return normalizedUrl.startsWith('/') ? normalizedUrl : `/${normalizedUrl}`;
+  }
+
+  return `${lmsBaseUrl.replace(/\/$/, '')}/${normalizedUrl.replace(/^\//, '')}`;
+}
+
+function getFilePreviewKind(isImage, isPdf) {
+  if (isImage) {
+    return 'image';
+  }
+
+  if (isPdf) {
+    return 'pdf';
+  }
+
+  return 'document';
+}
+
+export function revokeFilePreviewUrl(fileValue) {
+  if (
+    fileValue?.previewUrl
+    && String(fileValue.previewUrl).startsWith('blob:')
+    && typeof URL !== 'undefined'
+    && URL.revokeObjectURL
+  ) {
+    URL.revokeObjectURL(fileValue.previewUrl);
+  }
+}
+
+export function getFilePreview(fileValue) {
+  if (!fileValue) {
+    return null;
+  }
+
+  if (typeof fileValue === 'string') {
+    const url = resolveFilePreviewUrl(fileValue);
+    const name = getFileNameFromUrl(url);
+    const extension = getFileExtension(url);
+    const isImage = ['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(extension);
+    const isPdf = extension === 'pdf';
+
+    return {
+      name,
+      url,
+      kind: getFilePreviewKind(isImage, isPdf),
+      canOpen: Boolean(url),
+    };
+  }
+
+  const fileBlob = getFileUploadBlob(fileValue);
+  const rawUrl = fileValue.previewUrl || fileValue.url || fileValue.imageUrl || '';
+  const url = resolveFilePreviewUrl(rawUrl);
+  const name = fileValue.name || fileBlob?.name || getFileNameFromUrl(url);
+  const mimeType = String(fileValue.type || fileBlob?.type || '').toLowerCase();
+  const extension = getFileExtension(name) || getFileExtension(url);
+  const isImage = mimeType.startsWith('image/')
+    || ['jpg', 'jpeg', 'png', 'webp', 'gif'].includes(extension);
+  const isPdf = mimeType === 'application/pdf' || extension === 'pdf';
+
+  return {
+    name,
+    url,
+    kind: getFilePreviewKind(isImage, isPdf),
+    canOpen: Boolean(url),
+  };
+}
+
+function normalizeFileFieldValue(storedValue) {
+  if (!storedValue) {
+    return null;
+  }
+
+  if (isBrowserFile(storedValue)) {
+    return createFileUploadValue(storedValue);
+  }
+
+  if (typeof storedValue === 'object') {
+    if (getFileUploadBlob(storedValue)) {
+      return {
+        ...storedValue,
+        name: storedValue.name || storedValue.file.name,
+        type: storedValue.type || storedValue.file.type,
+        size: storedValue.size || storedValue.file.size,
+      };
+    }
+
+    if (storedValue.name && (storedValue.url || storedValue.imageUrl || storedValue.previewUrl)) {
+      return {
+        name: String(storedValue.name),
+        ...(storedValue.url ? { url: String(storedValue.url) } : {}),
+        ...(storedValue.imageUrl ? { imageUrl: String(storedValue.imageUrl) } : {}),
+        ...(storedValue.previewUrl ? { previewUrl: String(storedValue.previewUrl) } : {}),
+        ...(storedValue.type ? { type: String(storedValue.type) } : {}),
+        ...(storedValue.size ? { size: storedValue.size } : {}),
+      };
+    }
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue);
+    if (parsed && parsed.name && (parsed.url || parsed.imageUrl || parsed.previewUrl)) {
+      return {
+        name: String(parsed.name),
+        ...(parsed.url ? { url: String(parsed.url) } : {}),
+        ...(parsed.imageUrl ? { imageUrl: String(parsed.imageUrl) } : {}),
+        ...(parsed.previewUrl ? { previewUrl: String(parsed.previewUrl) } : {}),
+        ...(parsed.type ? { type: String(parsed.type) } : {}),
+        ...(parsed.size ? { size: parsed.size } : {}),
+      };
+    }
+  } catch (error) {
+    return {
+      name: String(storedValue).split('/').pop() || 'file',
+      url: String(storedValue),
+    };
+  }
+
+  return null;
+}
+
+function normalizeCnicValue(value) {
+  return String(value || '').trim().replace(/^(\d{5})\s+(\d{7}-\d)$/, '$1-$2');
+}
+
+function compactPhoneValue(value) {
+  return String(value || '').trim();
+}
+
+export function isValidPakistanMobileNumber(value) {
+  return PAKISTAN_MOBILE_FORMAT.test(compactPhoneValue(value));
+}
+
+export function normalizePakistanMobileValue(value) {
+  const compactValue = compactPhoneValue(value);
+
+  if (!isValidPakistanMobileNumber(compactValue)) {
+    return String(value || '').trim();
+  }
+
+  if (compactValue.startsWith('+92')) {
+    return compactValue;
+  }
+
+  if (compactValue.startsWith('92')) {
+    return `+${compactValue}`;
+  }
+
+  return `+92${compactValue.slice(1)}`;
+}
+
+function normalizePhoneFields(sanitizedData) {
+  const normalizedData = { ...sanitizedData };
+
+  PAKISTAN_MOBILE_FIELD_NAMES.forEach((fieldName) => {
+    if (sanitizedData[fieldName] !== undefined) {
+      normalizedData[fieldName] = normalizePakistanMobileValue(sanitizedData[fieldName]);
+    }
+  });
+
+  return normalizedData;
+}
 
 function buildRepeatableRow(row, repeatableConfig) {
   const normalizedRow = repeatableConfig.columns.reduce((accumulator, column) => {
+    if (column.type === PROFILE_FIELD_TYPES.FILE) {
+      accumulator[column.key] = normalizeFileFieldValue(row && row[column.key]);
+      return accumulator;
+    }
+
     accumulator[column.key] = String((row && row[column.key]) || '');
     return accumulator;
   }, {});
@@ -25,6 +315,88 @@ function buildRepeatableRow(row, repeatableConfig) {
   };
 }
 
+function normalizeProtectedRowValue(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function hasProtectedRows(repeatableConfig) {
+  return Boolean(
+    repeatableConfig.protectedRowKey
+    && Array.isArray(repeatableConfig.protectedRows)
+    && repeatableConfig.protectedRows.length > 0,
+  );
+}
+
+export function isProtectedRepeatableRow(row, repeatableConfig) {
+  if (!hasProtectedRows(repeatableConfig)) {
+    return false;
+  }
+
+  const protectedValues = repeatableConfig.protectedRows.map(protectedRow => (
+    normalizeProtectedRowValue(protectedRow[repeatableConfig.protectedRowKey])
+  ));
+
+  return protectedValues.includes(normalizeProtectedRowValue(row?.[repeatableConfig.protectedRowKey]));
+}
+
+export function isProtectedRepeatableColumn(row, repeatableConfig, columnKey) {
+  return isProtectedRepeatableRow(row, repeatableConfig)
+    && (repeatableConfig.protectedColumns || []).includes(columnKey);
+}
+
+function normalizeProtectedRepeatableRows(rows, repeatableConfig) {
+  if (!hasProtectedRows(repeatableConfig)) {
+    return rows;
+  }
+
+  const protectedColumns = repeatableConfig.protectedColumns || [];
+  const protectedRows = repeatableConfig.protectedRows.map((protectedRow) => {
+    const matchingRow = rows.find(row => (
+      normalizeProtectedRowValue(row?.[repeatableConfig.protectedRowKey])
+      === normalizeProtectedRowValue(protectedRow[repeatableConfig.protectedRowKey])
+    ));
+
+    if (!matchingRow) {
+      return buildRepeatableRow({
+        ...repeatableConfig.emptyRow,
+        ...protectedRow,
+      }, repeatableConfig);
+    }
+
+    return protectedColumns.reduce((accumulator, columnKey) => ({
+      ...accumulator,
+      [columnKey]: String(protectedRow[columnKey] || ''),
+    }), { ...matchingRow });
+  });
+
+  const protectedValues = new Set(repeatableConfig.protectedRows.map(protectedRow => (
+    normalizeProtectedRowValue(protectedRow[repeatableConfig.protectedRowKey])
+  )));
+  const customRows = rows.filter(row => (
+    !protectedValues.has(normalizeProtectedRowValue(row?.[repeatableConfig.protectedRowKey]))
+  ));
+
+  return [...protectedRows, ...customRows];
+}
+
+export function normalizeAutoPriorityRows(rows, repeatableConfig) {
+  if (!repeatableConfig.autoPriorityKey) {
+    return rows;
+  }
+
+  return (rows || []).map((row, index) => ({
+    ...row,
+    [repeatableConfig.autoPriorityKey]: String(index + 1),
+  }));
+}
+
+export function normalizeRepeatableRows(rows, repeatableConfig) {
+  return normalizeAutoPriorityRows(
+    normalizeProtectedRepeatableRows(rows, repeatableConfig),
+    repeatableConfig,
+  );
+}
+
 export function getExtendedProfileValue(extendedProfile, fieldName) {
   const field = (extendedProfile || []).find((item) => item.fieldName === fieldName);
   return field ? field.fieldValue : '';
@@ -32,6 +404,22 @@ export function getExtendedProfileValue(extendedProfile, fieldName) {
 
 export function isSingleMaritalStatus(value) {
   return String(value || '').trim().toLowerCase() === 'single';
+}
+
+export function shouldShowSpouseInformation(value) {
+  return String(value || '').trim().length > 0 && !isSingleMaritalStatus(value);
+}
+
+export function isFirstJob(value) {
+  return String(value || '').trim().toLowerCase() === 'yes';
+}
+
+export function hasPreviousEmployment(value) {
+  return String(value || '').trim().toLowerCase() === 'no';
+}
+
+export function hasOtherIncome(value) {
+  return String(value || '').trim().toLowerCase() === 'yes';
 }
 
 export function normalizeFieldValue(field, storedValue) {
@@ -43,33 +431,59 @@ export function normalizeFieldValue(field, storedValue) {
 }
 
 export function parseRepeatableRows(storedValue, repeatableConfig) {
+  const defaultRows = repeatableConfig.defaultRows || [];
+  const buildRows = rows => normalizeRepeatableRows(
+    rows.map(row => buildRepeatableRow(row, repeatableConfig)),
+    repeatableConfig,
+  );
+  const buildEmptyRows = () => buildRows([repeatableConfig.emptyRow]);
+
   if (!storedValue) {
-    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+    if (defaultRows.length > 0) {
+      return buildRows(defaultRows);
+    }
+    return buildEmptyRows();
   }
 
   if (Array.isArray(storedValue)) {
     if (storedValue.length > 0) {
-      return storedValue.map((row) => buildRepeatableRow(row, repeatableConfig));
+      return buildRows(storedValue);
     }
-    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+    if (defaultRows.length > 0) {
+      return buildRows(defaultRows);
+    }
+    return buildEmptyRows();
   }
 
   try {
     const parsed = JSON.parse(storedValue);
     if (Array.isArray(parsed) && parsed.length > 0) {
-      return parsed.map((row) => buildRepeatableRow(row, repeatableConfig));
+      return buildRows(parsed);
+    }
+    if (Array.isArray(parsed) && defaultRows.length > 0) {
+      return buildRows(defaultRows);
     }
   } catch (error) {
-    return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+    return buildEmptyRows();
   }
 
-  return [buildRepeatableRow(repeatableConfig.emptyRow, repeatableConfig)];
+  if (defaultRows.length > 0) {
+    return buildRows(defaultRows);
+  }
+
+  return buildEmptyRows();
 }
 
 export function serializeRepeatableRows(rows, repeatableConfig) {
   return JSON.stringify((rows || [])
     .map((row) => {
       const normalizedRow = repeatableConfig.columns.reduce((accumulator, column) => {
+        if (column.type === PROFILE_FIELD_TYPES.FILE) {
+          const fileValue = normalizeFileFieldValue(row && row[column.key]);
+          accumulator[column.key] = fileValue?.url || fileValue?.name || '';
+          return accumulator;
+        }
+
         accumulator[column.key] = String((row && row[column.key]) || '').trim();
         return accumulator;
       }, {});
@@ -81,63 +495,17 @@ export function serializeRepeatableRows(rows, repeatableConfig) {
       return normalizedRow;
     })
     .filter((row) => Object.entries(row)
-      .some(([key, value]) => key === 'backendId' || value.length > 0)));
+      .some(([key, value]) => key === 'backendId' || String(value || '').length > 0)));
 }
 
 export function parseFileFieldValue(storedValue) {
-  if (!storedValue) {
-    return null;
-  }
-
-  if (typeof storedValue === 'object') {
-    if (storedValue.name && (storedValue.dataUrl || storedValue.url)) {
-      return {
-        name: String(storedValue.name),
-        ...(storedValue.dataUrl ? { dataUrl: String(storedValue.dataUrl) } : {}),
-        ...(storedValue.url ? { url: String(storedValue.url) } : {}),
-      };
-    }
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(storedValue);
-    if (parsed && parsed.name && (parsed.dataUrl || parsed.url)) {
-      return {
-        name: String(parsed.name),
-        ...(parsed.dataUrl ? { dataUrl: String(parsed.dataUrl) } : {}),
-        ...(parsed.url ? { url: String(parsed.url) } : {}),
-      };
-    }
-  } catch (error) {
-    return {
-      name: String(storedValue).split('/').pop() || 'file',
-      url: String(storedValue),
-    };
-  }
-
-  return null;
+  return normalizeFileFieldValue(storedValue);
 }
 
 export function serializeFileFieldValue(fileValue) {
-  if (!fileValue || !fileValue.name || (!fileValue.dataUrl && !fileValue.url)) {
-    return '';
-  }
+  const normalizedValue = normalizeFileFieldValue(fileValue);
 
-  return JSON.stringify({
-    name: fileValue.name,
-    ...(fileValue.dataUrl ? { dataUrl: fileValue.dataUrl } : {}),
-    ...(fileValue.url ? { url: fileValue.url } : {}),
-  });
-}
-
-export function readFileAsDataUrl(file) {
-  return new Promise((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onload = () => resolve(reader.result);
-    reader.onerror = reject;
-    reader.readAsDataURL(file);
-  });
+  return normalizedValue?.url || normalizedValue?.name || '';
 }
 
 export function getSectionInitialData(section, extendedProfile) {
@@ -164,7 +532,10 @@ export function getSectionInitialData(section, extendedProfile) {
     return accumulator;
   }, {});
 
+  const submittedFieldName = getSectionSubmittedFieldName(section.id);
+  const hasSubmittedField = (extendedProfile || []).some(entry => entry.fieldName === submittedFieldName);
   const toggleValues = [
+    ...(hasSubmittedField ? [{ fieldName: submittedFieldName, type: PROFILE_FIELD_TYPES.CHECKBOX }] : []),
     ...(section.naFieldName ? [{ fieldName: section.naFieldName, type: PROFILE_FIELD_TYPES.CHECKBOX }] : []),
     ...((section.repeatables || [])
       .filter((repeatable) => repeatable.naFieldName)
@@ -189,7 +560,13 @@ export function getSectionInitialData(section, extendedProfile) {
 }
 
 export function getSanitizedSectionData(section, sectionData) {
-  const sanitizedData = { ...sectionData };
+  let sanitizedData = { ...sectionData };
+
+  if (section.id === 'basicInformation') {
+    sanitizedData.identity_card_number = normalizeCnicValue(sanitizedData.identity_card_number);
+  }
+
+  sanitizedData = normalizePhoneFields(sanitizedData);
 
   if (section.naFieldName && sanitizedData[section.naFieldName]) {
     (section.fields || []).forEach((field) => {
@@ -206,6 +583,11 @@ export function getSanitizedSectionData(section, sectionData) {
   (section.repeatables || []).forEach((repeatable) => {
     if (repeatable.naFieldName && sanitizedData[repeatable.naFieldName]) {
       sanitizedData[repeatable.storageFieldName] = [buildRepeatableRow(repeatable.emptyRow, repeatable)];
+    } else {
+      sanitizedData[repeatable.storageFieldName] = normalizeRepeatableRows(
+        sanitizedData[repeatable.storageFieldName] || [],
+        repeatable,
+      );
     }
   });
 
@@ -215,7 +597,311 @@ export function getSanitizedSectionData(section, sectionData) {
     });
   }
 
+  if (section.id === 'employment') {
+    if (isFirstJob(sanitizedData[FIRST_JOB_FIELD_NAME])) {
+      const employmentRepeatable = section.repeatables?.find(
+        repeatable => repeatable.storageFieldName === EMPLOYMENT_RECORDS_FIELD_NAME,
+      );
+      if (employmentRepeatable) {
+        sanitizedData[EMPLOYMENT_RECORDS_FIELD_NAME] = [buildRepeatableRow(
+          employmentRepeatable.emptyRow,
+          employmentRepeatable,
+        )];
+      }
+    } else if (hasPreviousEmployment(sanitizedData[FIRST_JOB_FIELD_NAME])) {
+      sanitizedData[FIRST_JOB_GAP_FIELD_NAME] = '';
+    } else {
+      sanitizedData[FIRST_JOB_GAP_FIELD_NAME] = '';
+    }
+  }
+
+  if (
+    section.id === GOVERNMENT_SERVICE_DETAILS_SECTION_ID
+    && !hasOtherIncome(sanitizedData[OTHER_INCOME_SOURCE_FIELD_NAME])
+  ) {
+    sanitizedData[OTHER_INCOME_DETAILS_FIELD_NAME] = '';
+  }
+
   return sanitizedData;
+}
+
+export function getVisibleSectionFields(section, sectionData) {
+  return (section.fields || []).filter((field) => (
+    (
+      section.id !== 'basicInformation'
+      || !BASIC_INFORMATION_CHILD_FIELD_NAMES.includes(field.fieldName)
+      || shouldShowSpouseInformation(sectionData.marital_status)
+    )
+    && (
+      section.id !== 'employment'
+      || field.fieldName === FIRST_JOB_FIELD_NAME
+      || (field.fieldName === FIRST_JOB_GAP_FIELD_NAME && isFirstJob(sectionData[FIRST_JOB_FIELD_NAME]))
+    )
+    && (
+      section.id !== GOVERNMENT_SERVICE_DETAILS_SECTION_ID
+      || field.fieldName !== OTHER_INCOME_DETAILS_FIELD_NAME
+      || hasOtherIncome(sectionData[OTHER_INCOME_SOURCE_FIELD_NAME])
+    )
+  ));
+}
+
+export function getVisibleSectionRepeatables(section, sectionData) {
+  return (section.repeatables || []).filter((repeatable) => (
+    section.id !== 'employment'
+    || repeatable.storageFieldName !== EMPLOYMENT_RECORDS_FIELD_NAME
+    || hasPreviousEmployment(sectionData[FIRST_JOB_FIELD_NAME])
+  ));
+}
+
+function hasFieldValue(value) {
+  return String(value ?? '').trim().length > 0;
+}
+
+function getRequiredFieldMessage(label) {
+  return `${label} is required.`;
+}
+
+export function getRepeatableFieldErrorKey(repeatable, row, fieldName) {
+  return `${repeatable.storageFieldName}.${row?.rowId || 'row'}.${fieldName}`;
+}
+
+function getRepeatableFieldError(repeatable, row, fieldName, userMessage) {
+  return {
+    fieldName: getRepeatableFieldErrorKey(repeatable, row, fieldName),
+    userMessage,
+  };
+}
+
+function isValidDateValue(value) {
+  return DATE_FORMAT.test(String(value ?? '').trim());
+}
+
+function getYearFromDateValue(value) {
+  return String(value || '').slice(0, 4);
+}
+
+function validateFieldFormat(field, value) {
+  const trimmedValue = String(value ?? '').trim();
+
+  if (!trimmedValue) {
+    return '';
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.DATE && !DATE_FORMAT.test(trimmedValue)) {
+    return 'Enter a valid date in YYYY-MM-DD format.';
+  }
+
+  if (field.fieldName === 'identity_card_number' && !CNIC_FORMAT.test(trimmedValue)) {
+    return 'Enter a valid 13-digit CNIC number.';
+  }
+
+  if (field.fieldName === 'contact_email' && !EMAIL_FORMAT.test(trimmedValue)) {
+    return 'Enter a valid email address.';
+  }
+
+  if (PAKISTAN_MOBILE_FIELD_NAMES.includes(field.fieldName) && !isValidPakistanMobileNumber(trimmedValue)) {
+    return PAKISTAN_MOBILE_VALIDATION_MESSAGE;
+  }
+
+  if (field.type === PROFILE_FIELD_TYPES.NUMBER && Number.isNaN(Number(trimmedValue))) {
+    return `${field.label} must be a number.`;
+  }
+
+  return '';
+}
+
+function validateEducationRowDateRules(repeatable, row) {
+  const validationErrors = {};
+  const attendedFrom = String(row.attended_from || '').trim();
+  const attendedTo = String(row.attended_to || '').trim();
+  const yearOfPassing = String(row.year_of_passing || '').trim();
+
+  if (isValidDateValue(attendedFrom) && isValidDateValue(attendedTo) && attendedTo < attendedFrom) {
+    const error = getRepeatableFieldError(repeatable, row, 'attended_to', EDUCATION_ATTENDED_TO_DATE_MESSAGE);
+    validationErrors[error.fieldName] = { userMessage: error.userMessage };
+  }
+
+  if (isValidDateValue(attendedTo) && yearOfPassing && yearOfPassing !== getYearFromDateValue(attendedTo)) {
+    const error = getRepeatableFieldError(repeatable, row, 'year_of_passing', EDUCATION_YEAR_OF_PASSING_MESSAGE);
+    validationErrors[error.fieldName] = { userMessage: error.userMessage };
+  }
+
+  return validationErrors;
+}
+
+function validateEmploymentRowDateRules(repeatable, row) {
+  const validationErrors = {};
+  const fromDate = String(row.from || '').trim();
+  const toDate = String(row.to || '').trim();
+
+  if (isValidDateValue(fromDate) && isValidDateValue(toDate) && toDate < fromDate) {
+    const error = getRepeatableFieldError(repeatable, row, 'to', EMPLOYMENT_TO_DATE_MESSAGE);
+    validationErrors[error.fieldName] = { userMessage: error.userMessage };
+  }
+
+  return validationErrors;
+}
+
+function validateForeignVisitRowDateRules(repeatable, row) {
+  const validationErrors = {};
+  const fromDate = String(row.from || '').trim();
+  const toDate = String(row.to || '').trim();
+
+  if (isValidDateValue(fromDate) && isValidDateValue(toDate) && toDate < fromDate) {
+    const error = getRepeatableFieldError(repeatable, row, 'to', FOREIGN_VISIT_TO_DATE_MESSAGE);
+    validationErrors[error.fieldName] = { userMessage: error.userMessage };
+  }
+
+  return validationErrors;
+}
+
+export function validateSectionDateRules(section, sectionData) {
+  const validationErrors = {};
+
+  if (section.id === EDUCATION_SECTION_ID) {
+    const educationRepeatable = (section.repeatables || [])
+      .find(repeatable => repeatable.storageFieldName === EDUCATION_RECORDS_FIELD_NAME);
+
+    (sectionData[EDUCATION_RECORDS_FIELD_NAME] || []).forEach((row) => {
+      Object.assign(validationErrors, validateEducationRowDateRules(educationRepeatable, row));
+    });
+  }
+
+  if (section.id === FOREIGN_VISITS_SECTION_ID) {
+    const foreignVisitsRepeatable = (section.repeatables || [])
+      .find(repeatable => repeatable.storageFieldName === FOREIGN_VISITS_FIELD_NAME);
+
+    if (!sectionData[section.naFieldName]) {
+      (sectionData[FOREIGN_VISITS_FIELD_NAME] || []).forEach((row) => {
+        Object.assign(validationErrors, validateForeignVisitRowDateRules(foreignVisitsRepeatable, row));
+      });
+    }
+  }
+
+  if (section.id === EMPLOYMENT_SECTION_ID) {
+    const employmentRepeatable = (section.repeatables || [])
+      .find(repeatable => repeatable.storageFieldName === EMPLOYMENT_RECORDS_FIELD_NAME);
+
+    (sectionData[EMPLOYMENT_RECORDS_FIELD_NAME] || []).forEach((row) => {
+      Object.assign(validationErrors, validateEmploymentRowDateRules(employmentRepeatable, row));
+    });
+  }
+
+  return validationErrors;
+}
+
+export function validateSectionDraft(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+  const validationErrors = {
+    ...validateSectionDateRules(section, sanitizedData),
+  };
+
+  if (section.naFieldName && sanitizedData[section.naFieldName]) {
+    return validationErrors;
+  }
+
+  getVisibleSectionFields(section, sanitizedData).forEach((field) => {
+    const value = sanitizedData[field.fieldName];
+
+    if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
+      if (!value) {
+        validationErrors[field.fieldName] = {
+          userMessage: getRequiredFieldMessage(field.label),
+        };
+      }
+      return;
+    }
+
+    if (!hasFieldValue(value)) {
+      validationErrors[field.fieldName] = {
+        userMessage: getRequiredFieldMessage(field.label),
+      };
+      return;
+    }
+
+    const formatError = validateFieldFormat(field, value);
+    if (formatError) {
+      validationErrors[field.fieldName] = {
+        userMessage: formatError,
+      };
+    }
+  });
+
+  getVisibleSectionRepeatables(section, sanitizedData).forEach((repeatable) => {
+    if (repeatable.naFieldName && sanitizedData[repeatable.naFieldName]) {
+      return;
+    }
+
+    const rows = sanitizedData[repeatable.storageFieldName] || [];
+    if (rows.length === 0) {
+      validationErrors[repeatable.storageFieldName] = {
+        userMessage: `${repeatable.itemLabel} is required.`,
+      };
+      return;
+    }
+
+    rows.forEach((row) => {
+      repeatable.columns.forEach((column) => {
+        const value = row[column.key];
+
+        if (column.type === PROFILE_FIELD_TYPES.FILE) {
+          if (!value) {
+            validationErrors[column.key] = {
+              userMessage: `Upload ${column.label}.`,
+            };
+          }
+          return;
+        }
+
+        if (!hasFieldValue(value)) {
+          validationErrors[column.key] = {
+            userMessage: getRequiredFieldMessage(column.label),
+          };
+          return;
+        }
+
+        const formatError = validateFieldFormat(
+          {
+            ...column,
+            fieldName: column.key,
+          },
+          value,
+        );
+        if (formatError) {
+          validationErrors[column.key] = {
+            userMessage: formatError,
+          };
+          return;
+        }
+
+        if (column.validate) {
+          const customError = column.validate(value, row);
+          if (customError) {
+            validationErrors[column.key] = { userMessage: customError };
+          }
+        }
+      });
+    });
+  });
+
+  (section.fileFields || []).forEach((field) => {
+    const dependencyFieldName = CONDITIONAL_FILE_FIELD_DEPENDENCIES[field.fieldName];
+    const shouldRequireFile = dependencyFieldName
+      ? hasFieldValue(sanitizedData[dependencyFieldName])
+      : true;
+
+    if (!shouldRequireFile) {
+      return;
+    }
+
+    if (!sanitizedData[field.fieldName]) {
+      validationErrors[field.fieldName] = {
+        userMessage: `Upload ${field.label}.`,
+      };
+    }
+  });
+
+  return validationErrors;
 }
 
 export function getSectionPayload(section, sectionData) {
@@ -259,8 +945,107 @@ export function getSectionById(sectionId) {
   return BIODATA_SECTION_MAP[sectionId] || null;
 }
 
-function rowHasUserValue(row, repeatable) {
-  return repeatable.columns.some((column) => String(row[column.key] || '').trim().length > 0);
+function isDefaultRepeatableRow(row, repeatable, rowIndex) {
+  const defaultRow = repeatable.defaultRows?.[rowIndex];
+
+  if (!defaultRow) {
+    return false;
+  }
+
+  return repeatable.columns.every((column) => {
+    if (column.type === PROFILE_FIELD_TYPES.FILE) {
+      return !row[column.key] && !defaultRow[column.key];
+    }
+
+    return String(row[column.key] || '').trim() === String(defaultRow[column.key] || '').trim();
+  });
+}
+
+function rowHasUserValue(row, repeatable, rowIndex = null) {
+  if (rowIndex !== null && isDefaultRepeatableRow(row, repeatable, rowIndex)) {
+    return false;
+  }
+
+  return repeatable.columns.some((column) => {
+    if (column.displayOnly || isProtectedRepeatableColumn(row, repeatable, column.key)) {
+      return false;
+    }
+
+    if (column.type === PROFILE_FIELD_TYPES.FILE) {
+      return Boolean(row[column.key]);
+    }
+
+    return String(row[column.key] || '').trim().length > 0;
+  });
+}
+
+function isFilled(value) {
+  return String(value ?? '').trim().length > 0;
+}
+
+function findRepeatable(section, storageFieldName) {
+  return (section.repeatables || []).find(repeatable => repeatable.storageFieldName === storageFieldName);
+}
+
+function hasCompleteCssServicePreferences(section, sectionData) {
+  const servicePreferenceRepeatable = findRepeatable(section, CSS_SERVICE_PREFERENCES_FIELD_NAME);
+
+  if (!servicePreferenceRepeatable) {
+    return true;
+  }
+
+  return (sectionData[CSS_SERVICE_PREFERENCES_FIELD_NAME] || []).some(row => (
+    isFilled(row.service_group) || isFilled(row.service_group_preference)
+  ));
+}
+
+function hasCompleteCompulsoryCssSubjectMarks(section, sectionData) {
+  const subjectMarksRepeatable = findRepeatable(section, CSS_SUBJECT_MARKS_FIELD_NAME);
+
+  if (!subjectMarksRepeatable?.protectedRows?.length) {
+    return true;
+  }
+
+  const subjectRows = sectionData[CSS_SUBJECT_MARKS_FIELD_NAME] || [];
+
+  return subjectMarksRepeatable.protectedRows.every((protectedRow) => {
+    const matchingRow = subjectRows.find(row => (
+      normalizeProtectedRowValue(row?.[subjectMarksRepeatable.protectedRowKey])
+      === normalizeProtectedRowValue(protectedRow[subjectMarksRepeatable.protectedRowKey])
+    ));
+
+    return Boolean(matchingRow) && isFilled(matchingRow.marks_obtained);
+  });
+}
+
+function cssExamDetailsHasRequiredValues(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+  const hasRequiredFlatFields = getVisibleSectionFields(section, sanitizedData).every(field => (
+    field.type === PROFILE_FIELD_TYPES.CHECKBOX
+      ? Boolean(sanitizedData[field.fieldName])
+      : isFilled(sanitizedData[field.fieldName])
+  ));
+
+  return hasRequiredFlatFields
+    && hasCompleteCssServicePreferences(section, sanitizedData)
+    && hasCompleteCompulsoryCssSubjectMarks(section, sanitizedData);
+}
+
+function employmentHasRequiredValues(section, sectionData) {
+  const sanitizedData = getSanitizedSectionData(section, sectionData);
+
+  if (isFirstJob(sanitizedData[FIRST_JOB_FIELD_NAME])) {
+    return isFilled(sanitizedData[FIRST_JOB_GAP_FIELD_NAME]);
+  }
+
+  if (hasPreviousEmployment(sanitizedData[FIRST_JOB_FIELD_NAME])) {
+    const employmentRepeatable = findRepeatable(section, EMPLOYMENT_RECORDS_FIELD_NAME);
+
+    return (sanitizedData[EMPLOYMENT_RECORDS_FIELD_NAME] || [])
+      .some((row, rowIndex) => rowHasUserValue(row, employmentRepeatable, rowIndex));
+  }
+
+  return false;
 }
 
 export function sectionHasValue(section, sectionData) {
@@ -276,20 +1061,20 @@ export function sectionHasValue(section, sectionData) {
     return true;
   }
 
-  const hasFieldValue = (section.fields || []).some((field) => {
+  const hasCompletedField = (section.fields || []).some((field) => {
     if (field.type === PROFILE_FIELD_TYPES.CHECKBOX) {
       return Boolean(sectionData[field.fieldName]);
     }
     return String(sectionData[field.fieldName] || '').trim().length > 0;
   });
 
-  if (hasFieldValue) {
+  if (hasCompletedField) {
     return true;
   }
 
   const hasRepeatableValue = (section.repeatables || []).some((repeatable) => (
-    (sectionData[repeatable.storageFieldName] || []).some((row) => (
-      rowHasUserValue(row, repeatable)
+    (sectionData[repeatable.storageFieldName] || []).some((row, rowIndex) => (
+      rowHasUserValue(row, repeatable, rowIndex)
     ))
   ));
 
@@ -298,6 +1083,26 @@ export function sectionHasValue(section, sectionData) {
   }
 
   return (section.fileFields || []).some((field) => Boolean(sectionData[field.fieldName]));
+}
+
+export function sectionIsComplete(section, sectionData) {
+  let locallyComplete = sectionHasValue(section, sectionData);
+
+  if (section.id === CSS_EXAM_DETAILS_SECTION_ID) {
+    locallyComplete = cssExamDetailsHasRequiredValues(section, sectionData);
+  }
+
+  if (section.id === 'employment') {
+    locallyComplete = employmentHasRequiredValues(section, sectionData);
+  }
+
+  const submittedFieldName = getSectionSubmittedFieldName(section.id);
+
+  if (Object.prototype.hasOwnProperty.call(sectionData || {}, submittedFieldName)) {
+    return locallyComplete && Boolean(sectionData[submittedFieldName]);
+  }
+
+  return locallyComplete;
 }
 
 export function getSectionSummary(section, sectionData) {
@@ -323,7 +1128,7 @@ export function getSectionSummary(section, sectionData) {
   for (let index = 0; index < (section.repeatables || []).length; index += 1) {
     const repeatable = section.repeatables[index];
     const filledRows = (sectionData[repeatable.storageFieldName] || [])
-      .filter((row) => rowHasUserValue(row, repeatable));
+      .filter((row, rowIndex) => rowHasUserValue(row, repeatable, rowIndex));
 
     if (filledRows.length > 0) {
       const previewColumn = repeatable.columns.find((column) => (
@@ -370,6 +1175,56 @@ export function getSectionError(section, errors) {
   }
 
   return errors.extendedProfile || errors[section.id] || null;
+}
+
+export function getSectionErrorFields(section, errors = {}, sectionData = null) {
+  const sanitizedData = sectionData ? getSanitizedSectionData(section, sectionData) : null;
+  const visibleFields = sanitizedData ? getVisibleSectionFields(section, sanitizedData) : (section.fields || []);
+  const visibleRepeatables = sanitizedData
+    ? getVisibleSectionRepeatables(section, sanitizedData)
+    : (section.repeatables || []);
+
+  return [
+    ...(visibleFields.map(({ fieldName, label }) => ({
+      fieldName,
+      label,
+    }))),
+    ...(visibleRepeatables.flatMap((repeatable) => [
+      {
+        fieldName: repeatable.storageFieldName,
+        label: repeatable.itemLabel,
+      },
+      ...repeatable.columns.map(({ key, label }) => ({
+        fieldName: key,
+        label,
+      })),
+    ])),
+    ...((section.fileFields || []).map(({ fieldName, label }) => ({
+      fieldName,
+      label,
+    }))),
+  ].filter(({ fieldName }) => (
+    Boolean(errors[fieldName])
+    || Object.keys(errors).some(errorFieldName => errorFieldName.endsWith(`.${fieldName}`))
+  ));
+}
+
+export function getSectionErrorSummary(section, errors = {}, sectionData = null) {
+  const errorFields = getSectionErrorFields(section, errors, sectionData);
+
+  if (errorFields.length === 0 && getSectionError(section, errors)) {
+    return 'Please review this section before continuing.';
+  }
+
+  if (errorFields.length === 0) {
+    return '';
+  }
+
+  if (errorFields.length === 1) {
+    return `Please fix ${errorFields[0].label}.`;
+  }
+
+  return `Please fix ${errorFields.length} fields in this section.`;
 }
 
 export function isBiodataForm(formId) {

--- a/src/profile/data/reducers.js
+++ b/src/profile/data/reducers.js
@@ -153,6 +153,8 @@ const profilePage = (state = initialState, action = {}) => {
       return {
         ...state,
         drafts: { ...state.drafts, [action.payload.name]: action.payload.value },
+        errors: {},
+        saveState: null,
       };
     case RESET_DRAFTS:
       return {

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -44,6 +44,7 @@ export function* handleFetchProfile(action) {
   let courseCertificates = null;
   let countriesCodesList = [];
   let biodataExtendedProfile = [];
+  let profileCompletionStatus = null;
 
   try {
     yield put(fetchProfileBegin());
@@ -57,15 +58,24 @@ export function* handleFetchProfile(action) {
     if (isAuthenticatedUserProfile) {
       calls.push(call(ProfileApiService.getPreferences, username));
       calls.push(call(ProfileApiService.getBiodataProfile));
+      calls.push(call(ProfileApiService.getProfileCompletionStatus, username));
     }
 
     const result = yield all(calls);
 
     if (isAuthenticatedUserProfile) {
-      [account, courseCertificates, countriesCodesList, preferences, biodataExtendedProfile] = result;
+      [
+        account,
+        courseCertificates,
+        countriesCodesList,
+        preferences,
+        biodataExtendedProfile,
+        profileCompletionStatus,
+      ] = result;
       account = {
         ...account,
         extendedProfile: biodataExtendedProfile,
+        profileCompletionStatus,
       };
     } else {
       [account, courseCertificates, countriesCodesList] = result;

--- a/src/profile/data/selectors.js
+++ b/src/profile/data/selectors.js
@@ -305,6 +305,8 @@ export const profilePageSelector = createSelector(
     isAuthenticatedUserProfile,
   ) => ({
     username: account.username,
+    extendedProfile: account.extendedProfile || [],
+    profileCompletionStatus: account.profileCompletionStatus || null,
     profileImage,
     requiresParentalConsent: account.requiresParentalConsent,
     dateJoined: account.dateJoined,

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -1,5 +1,8 @@
 import { ensureConfig, getConfig } from '@edx/frontend-platform';
-import { getAuthenticatedHttpClient as getHttpClient } from '@edx/frontend-platform/auth';
+import {
+  getAuthenticatedHttpClient as getHttpClient,
+  getAuthenticatedUser,
+} from '@edx/frontend-platform/auth';
 import { logError } from '@edx/frontend-platform/logging';
 import { camelCaseObject, convertKeyNames, snakeCaseObject } from '../utils';
 import { FIELD_LABELS } from './constants';
@@ -19,9 +22,19 @@ import {
   mergeSectionIntoExtendedProfile,
   normalizeBiodataErrorForSection,
 } from '../biodata/apiTransforms';
-import { getSectionById } from '../biodata/utils';
+import {
+  getFileUploadBlob,
+  getSectionById,
+  getSectionPayload,
+  getSectionSubmittedFieldName,
+} from '../biodata/utils';
 
 ensureConfig(['LMS_BASE_URL'], 'Profile API service');
+
+const PROFILE_COMPLETION_STORAGE_PREFIX = 'fbr.requiredProfileCompletion';
+const OUTSIDE_HRMS_INSTRUCTOR_STORAGE_PREFIX = 'fbr.outsideHrmsInstructorProfile';
+const DECLARATION_SECTION_ID = 'declaration';
+const DECLARATION_CONFIRMED_FIELD = 'declaration_confirmed';
 
 function processAccountData(data) {
   const processedData = camelCaseObject(data);
@@ -67,8 +80,71 @@ function getBiodataEndpointUrl(path) {
   return `${getBiodataApiBaseUrl()}/${normalizeBiodataPath(path)}`;
 }
 
+function getStorageUsername(username = null) {
+  return username || (
+    typeof getAuthenticatedUser === 'function'
+      ? getAuthenticatedUser()?.username
+      : null
+  ) || 'current-user';
+}
+
+function setStorageValue(key, value) {
+  if (typeof window === 'undefined' || !window.localStorage) {
+    return;
+  }
+
+  window.localStorage.setItem(key, value);
+}
+
+function getRequiredProfileCompletionStorageKey(username = null) {
+  return `${PROFILE_COMPLETION_STORAGE_PREFIX}:${getStorageUsername(username)}`;
+}
+
+function getOutsideHrmsInstructorStorageKey(username = null) {
+  return `${OUTSIDE_HRMS_INSTRUCTOR_STORAGE_PREFIX}:${getStorageUsername(username)}`;
+}
+
 function normalizeBiodataPayload(payload) {
   return snakeCaseObject(payload);
+}
+
+function hasMultipartValue(payload = {}) {
+  return Object.values(payload || {}).some(value => Boolean(getFileUploadBlob(value)));
+}
+
+function appendFormDataValue(formData, key, value) {
+  const file = getFileUploadBlob(value);
+  if (file) {
+    formData.append(key, file, file.name);
+    return;
+  }
+
+  if (value === undefined || value === null) {
+    return;
+  }
+
+  formData.append(key, typeof value === 'boolean' ? String(value) : value);
+}
+
+function buildBiodataRequestPayload(payload = {}) {
+  if (!hasMultipartValue(payload)) {
+    return {
+      data: normalizeBiodataPayload(payload),
+      headers: { 'Content-Type': 'application/json' },
+      isMultipart: false,
+    };
+  }
+
+  const formData = new FormData();
+  Object.entries(payload).forEach(([key, value]) => {
+    appendFormDataValue(formData, key, value);
+  });
+
+  return {
+    data: formData,
+    headers: undefined,
+    isMultipart: true,
+  };
 }
 
 function isMissingBiodataResponse(error) {
@@ -96,14 +172,80 @@ async function getFlatBiodataSection(section) {
   }
 }
 
-async function getRepeatableBiodataSection(section, repeatable, endpoint) {
+function shouldSkipRepeatableEndpoint(endpoint, flatResponse = {}) {
+  const skipRule = endpoint.skipWhenFlatFieldEquals;
+
+  return Boolean(skipRule && flatResponse?.[skipRule.fieldName] === skipRule.value);
+}
+
+function getLatestRepeatableRow(candidateRow = null, existingRow = null) {
+  if (!existingRow) {
+    return candidateRow;
+  }
+
+  const candidateTime = Date.parse(candidateRow?.modified || candidateRow?.created || '') || 0;
+  const existingTime = Date.parse(existingRow?.modified || existingRow?.created || '') || 0;
+
+  if (candidateTime !== existingTime) {
+    return candidateTime > existingTime ? candidateRow : existingRow;
+  }
+
+  return Number(candidateRow?.id || 0) > Number(existingRow?.id || 0) ? candidateRow : existingRow;
+}
+
+function dedupeRepeatableRows(endpoint, rows = []) {
+  if (!endpoint.dedupeBy) {
+    return rows;
+  }
+
+  const rowsByKey = rows.reduce((accumulator, row) => {
+    const key = String(row?.[endpoint.dedupeBy] || '').trim().toLowerCase();
+    if (!key) {
+      return accumulator;
+    }
+
+    accumulator[key] = getLatestRepeatableRow(row, accumulator[key]);
+    return accumulator;
+  }, {});
+
+  const dedupedKeys = new Set(Object.keys(rowsByKey));
+
+  return [
+    ...Object.values(rowsByKey),
+    ...rows.filter(row => !dedupedKeys.has(String(row?.[endpoint.dedupeBy] || '').trim().toLowerCase())),
+  ];
+}
+
+async function getRepeatableBiodataSection(section, repeatable, endpoint, flatResponse = {}) {
+  if (shouldSkipRepeatableEndpoint(endpoint, flatResponse)) {
+    return {
+      storageFieldName: repeatable.storageFieldName,
+      rows: [],
+      fallbackFields: {},
+    };
+  }
+
   try {
     const { data } = await getHttpClient().get(getBiodataEndpointUrl(endpoint.path));
-    const rows = Array.isArray(data) ? data : data?.results || [];
+    const rows = dedupeRepeatableRows(endpoint, Array.isArray(data) ? data : data?.results || []);
+    const metadataSource = Array.isArray(data) ? rows[0] : data;
+    const rowMetadataSource = !metadataSource?.not_applicable && !metadataSource?.is_submitted
+      ? rows.find(row => row?.not_applicable !== undefined || row?.is_submitted !== undefined)
+      : null;
+    const responseMetadata = rowMetadataSource || metadataSource || {};
+    const fallbackFields = {
+      ...(endpoint.fallbackNaFieldName && responseMetadata.not_applicable !== undefined
+        ? { [endpoint.fallbackNaFieldName]: Boolean(responseMetadata.not_applicable) }
+        : {}),
+      ...(responseMetadata.is_submitted !== undefined
+        ? { [getSectionSubmittedFieldName(section.id)]: Boolean(responseMetadata.is_submitted) }
+        : {}),
+    };
 
     return {
       storageFieldName: repeatable.storageFieldName,
       rows: rows.map(row => snakeCaseObject(row)),
+      fallbackFields,
     };
   } catch (error) {
     if (!isMissingBiodataResponse(error)) {
@@ -113,6 +255,7 @@ async function getRepeatableBiodataSection(section, repeatable, endpoint) {
     return {
       storageFieldName: repeatable.storageFieldName,
       rows: [],
+      fallbackFields: {},
     };
   }
 }
@@ -124,21 +267,54 @@ async function getBiodataSectionProfile(sectionId) {
     return [];
   }
 
-  const [flatResponse, ...repeatableResponses] = await Promise.all([
-    getFlatBiodataSection(section),
-    ...getSectionRepeatableConfigs(section)
-      .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(section, repeatable, endpoint)),
-  ]);
+  const flatResponse = await getFlatBiodataSection(section);
+  const repeatableResponses = await Promise.all(
+    getSectionRepeatableConfigs(section)
+      .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(
+        section,
+        repeatable,
+        endpoint,
+        flatResponse || {},
+      )),
+  );
 
   const repeatableResponsesByKey = repeatableResponses.reduce((accumulator, { storageFieldName, rows }) => {
     accumulator[storageFieldName] = rows;
     return accumulator;
   }, {});
+  const fallbackFields = repeatableResponses.reduce((accumulator, response) => ({
+    ...accumulator,
+    ...(response.fallbackFields || {}),
+  }), {});
 
-  return buildSectionExtendedProfile(sectionId, flatResponse || {}, repeatableResponsesByKey);
+  return buildSectionExtendedProfile(sectionId, {
+    ...(flatResponse || {}),
+    ...fallbackFields,
+  }, repeatableResponsesByKey);
 }
 
-async function updateRepeatableRows(endpointPath, committedRows, draftRows) {
+async function updateRepeatableRows(endpoint, committedRows, draftRows) {
+  const endpointPath = endpoint.path;
+  const shouldPostRows = endpoint.rowMethod === 'post';
+
+  if (endpoint.batchRows) {
+    if (draftRows.length === 0) {
+      return;
+    }
+
+    const rowValues = draftRows.map(row => row.values);
+    const payload = buildBiodataRequestPayload(
+      endpoint.batchPayloadKey ? { [endpoint.batchPayloadKey]: rowValues } : rowValues,
+    );
+    const url = getBiodataEndpointUrl(endpointPath);
+    if (payload.headers) {
+      await getHttpClient().post(url, payload.data, { headers: payload.headers });
+    } else {
+      await getHttpClient().post(url, payload.data);
+    }
+    return;
+  }
+
   const committedRowMap = committedRows.reduce((accumulator, row) => {
     if (row.backendId != null) {
       accumulator[String(row.backendId)] = row;
@@ -156,25 +332,27 @@ async function updateRepeatableRows(endpointPath, committedRows, draftRows) {
   const operations = [];
 
   draftRows.forEach((row) => {
-    const payload = normalizeBiodataPayload(row.values);
-    if (row.backendId != null) {
-      operations.push(getHttpClient().patch(
-        getBiodataEndpointUrl(`${endpointPath}${row.backendId}/`),
-        payload,
-        {
-          headers: { 'Content-Type': 'application/json' },
-        },
-      ));
+    const payload = buildBiodataRequestPayload(row.values);
+    if (row.backendId != null && !shouldPostRows) {
+      const url = getBiodataEndpointUrl(`${endpointPath}${row.backendId}/`);
+      operations.push(payload.headers
+        ? getHttpClient().patch(url, payload.data, { headers: payload.headers })
+        : getHttpClient().patch(url, payload.data));
     } else {
-      operations.push(getHttpClient().post(getBiodataEndpointUrl(endpointPath), payload));
+      const url = getBiodataEndpointUrl(endpointPath);
+      operations.push(payload.headers
+        ? getHttpClient().post(url, payload.data, { headers: payload.headers })
+        : getHttpClient().post(url, payload.data));
     }
   });
 
-  Object.keys(committedRowMap).forEach((backendId) => {
-    if (!draftRowMap[backendId]) {
-      operations.push(getHttpClient().delete(getBiodataEndpointUrl(`${endpointPath}${backendId}/`)));
-    }
-  });
+  if (!shouldPostRows) {
+    Object.keys(committedRowMap).forEach((backendId) => {
+      if (!draftRowMap[backendId]) {
+        operations.push(getHttpClient().delete(getBiodataEndpointUrl(`${endpointPath}${backendId}/`)));
+      }
+    });
+  }
 
   await Promise.all(operations);
 }
@@ -320,14 +498,26 @@ export async function getBiodataProfile() {
   const repeatableResponsesByKey = {};
 
   await Promise.all(sections.map(async (section) => {
-    const [flatResponse, ...repeatableResponses] = await Promise.all([
-      getFlatBiodataSection(section),
-      ...getSectionRepeatableConfigs(section)
-        .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(section, repeatable, endpoint)),
-    ]);
+    const flatResponse = await getFlatBiodataSection(section);
+    const repeatableResponses = await Promise.all(
+      getSectionRepeatableConfigs(section)
+        .map(({ repeatable, endpoint }) => getRepeatableBiodataSection(
+          section,
+          repeatable,
+          endpoint,
+          flatResponse || {},
+        )),
+    );
+    const fallbackFields = repeatableResponses.reduce((accumulator, response) => ({
+      ...accumulator,
+      ...(response.fallbackFields || {}),
+    }), {});
 
-    if (flatResponse) {
-      flatResponsesBySection[section.id] = flatResponse;
+    if (flatResponse || Object.keys(fallbackFields).length > 0) {
+      flatResponsesBySection[section.id] = {
+        ...(flatResponse || {}),
+        ...fallbackFields,
+      };
     }
 
     repeatableResponses.forEach(({ storageFieldName, rows }) => {
@@ -336,6 +526,43 @@ export async function getBiodataProfile() {
   }));
 
   return buildBiodataExtendedProfile(flatResponsesBySection, repeatableResponsesByKey);
+}
+
+export async function getProfileCompletionStatus() {
+  const declarationEndpoint = getSectionEndpointConfig(DECLARATION_SECTION_ID)?.flat?.path;
+  let complete = false;
+
+  if (declarationEndpoint) {
+    try {
+      const { data } = await getHttpClient().get(getBiodataEndpointUrl(declarationEndpoint));
+      complete = Boolean(snakeCaseObject(data || {}).is_submitted);
+    } catch (error) {
+      if (!isMissingBiodataResponse(error)) {
+        logError(error);
+      }
+    }
+  }
+
+  return {
+    required: true,
+    complete,
+    formType: 'biodata',
+    profileUrl: null,
+  };
+}
+
+export async function saveOutsideHrmsInstructorProfile(sectionData, username = null) {
+  setStorageValue(
+    getOutsideHrmsInstructorStorageKey(username),
+    JSON.stringify(normalizeBiodataPayload(sectionData)),
+  );
+  setStorageValue(getRequiredProfileCompletionStorageKey(username), 'true');
+
+  return getProfileCompletionStatus(username);
+}
+
+export async function saveRequiredProfileCompletion() {
+  return getProfileCompletionStatus();
 }
 
 export async function validateBiodataSection(sectionId, sectionData) {
@@ -364,28 +591,33 @@ export async function saveBiodataSection(sectionId, sectionData, committedData, 
 
   try {
     if (sectionEndpointConfig.flat?.path) {
-      const flatPayload = normalizeBiodataPayload(mapSectionDataToFlatPayload(section, sectionData));
-      await getHttpClient().patch(
-        getBiodataEndpointUrl(sectionEndpointConfig.flat.path),
-        flatPayload,
-        {
-          headers: { 'Content-Type': 'application/json' },
-        },
-      );
+      const flatPayload = buildBiodataRequestPayload(mapSectionDataToFlatPayload(section, sectionData));
+      const url = getBiodataEndpointUrl(sectionEndpointConfig.flat.path);
+      const requestMethod = sectionEndpointConfig.flat.method === 'post' ? 'post' : 'patch';
+      if (flatPayload.headers) {
+        await getHttpClient()[requestMethod](url, flatPayload.data, { headers: flatPayload.headers });
+      } else {
+        await getHttpClient()[requestMethod](url, flatPayload.data);
+      }
     }
 
     const repeatablePayloads = mapSectionDataToRepeatablePayloads(section, sectionData);
     const committedRepeatablePayloads = mapSectionDataToRepeatablePayloads(section, committedData || {});
 
     await Promise.all(repeatablePayloads.map(async (payload) => {
-      if (Object.keys(payload.extraFields).length > 0 && sectionEndpointConfig.flat?.path) {
-        await getHttpClient().patch(
-          getBiodataEndpointUrl(sectionEndpointConfig.flat.path),
-          normalizeBiodataPayload(payload.extraFields),
-          {
-            headers: { 'Content-Type': 'application/json' },
-          },
-        );
+      const extraFieldsEndpointPath = payload.endpoint.extraFieldMap
+        ? payload.endpoint.path
+        : sectionEndpointConfig.flat?.path;
+
+      if (Object.keys(payload.extraFields).length > 0 && extraFieldsEndpointPath) {
+        const extraPayload = buildBiodataRequestPayload(payload.extraFields);
+        const url = getBiodataEndpointUrl(extraFieldsEndpointPath);
+        const requestMethod = payload.endpoint.extraFieldsMethod === 'post' ? 'post' : 'patch';
+        if (extraPayload.headers) {
+          await getHttpClient()[requestMethod](url, extraPayload.data, { headers: extraPayload.headers });
+        } else {
+          await getHttpClient()[requestMethod](url, extraPayload.data);
+        }
       }
 
       const committedRepeatable = committedRepeatablePayloads.find(
@@ -393,19 +625,27 @@ export async function saveBiodataSection(sectionId, sectionData, committedData, 
       );
 
       await updateRepeatableRows(
-        payload.endpoint.path,
+        payload.endpoint,
         committedRepeatable?.rows || [],
         payload.rows,
       );
     }));
 
-    const savedSectionProfile = await getBiodataSectionProfile(sectionId);
+    const savedSectionProfile = sectionEndpointConfig.refreshAfterSave === false
+      ? getSectionPayload(section, sectionData)
+      : await getBiodataSectionProfile(sectionId);
+    const profileCompletionStatus = sectionId === DECLARATION_SECTION_ID
+      && sectionData?.[DECLARATION_CONFIRMED_FIELD]
+      ? await saveRequiredProfileCompletion()
+      : await getProfileCompletionStatus();
+
     return {
       extendedProfile: mergeSectionIntoExtendedProfile(
         sectionId,
         currentExtendedProfile,
         savedSectionProfile,
       ),
+      profileCompletionStatus,
     };
   } catch (error) {
     throw normalizeBiodataErrorForSection(error, sectionId);

--- a/src/profile/forms/outside-hrms/OutsideHrmsInstructorForm.jsx
+++ b/src/profile/forms/outside-hrms/OutsideHrmsInstructorForm.jsx
@@ -1,0 +1,155 @@
+import React, { useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import {
+  Alert, Button, Card, Form,
+} from '@openedx/paragon';
+
+import { saveOutsideHrmsInstructorProfile } from '../../data/services';
+
+const INITIAL_FORM_VALUE = {
+  name: '',
+  shortName: '',
+  designation: '',
+  phone: '',
+  mobile: '',
+  address: '',
+  expertise: '',
+  organization: '',
+  email: '',
+};
+
+const FORM_FIELDS = [
+  { key: 'name', label: 'Name', type: 'text' },
+  { key: 'shortName', label: 'Short Name', type: 'text' },
+  { key: 'designation', label: 'Designation', type: 'text' },
+  { key: 'phone', label: 'Phone', type: 'tel' },
+  { key: 'mobile', label: 'Mobile', type: 'tel' },
+  { key: 'address', label: 'Address', type: 'text' },
+  { key: 'expertise', label: 'Expertise', type: 'text' },
+  { key: 'organization', label: 'Organization', type: 'text' },
+  { key: 'email', label: 'Email', type: 'email' },
+];
+
+const getRequiredErrors = (formValue) => FORM_FIELDS.reduce((accumulator, field) => {
+  if (!String(formValue[field.key] || '').trim()) {
+    accumulator[field.key] = `${field.label} is required.`;
+  }
+  return accumulator;
+}, {});
+
+const OutsideHrmsInstructorForm = ({ onComplete, username }) => {
+  const [formValue, setFormValue] = useState(INITIAL_FORM_VALUE);
+  const [errors, setErrors] = useState({});
+  const [showSavedMessage, setShowSavedMessage] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
+  const errorCount = useMemo(() => Object.keys(errors).length, [errors]);
+
+  const handleChange = (fieldName, value) => {
+    setFormValue(previousValue => ({
+      ...previousValue,
+      [fieldName]: value,
+    }));
+    setErrors(previousErrors => {
+      const nextErrors = { ...previousErrors };
+      delete nextErrors[fieldName];
+      return nextErrors;
+    });
+    setShowSavedMessage(false);
+    setSaveError('');
+  };
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+
+    const nextErrors = getRequiredErrors(formValue);
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      setShowSavedMessage(false);
+      setSaveError('');
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveError('');
+
+    try {
+      const completionStatus = await saveOutsideHrmsInstructorProfile(formValue, username);
+      setFormValue(INITIAL_FORM_VALUE);
+      setErrors({});
+      setShowSavedMessage(true);
+      onComplete(completionStatus);
+    } catch (error) {
+      setShowSavedMessage(false);
+      setSaveError('Unable to save instructor details. Please try again.');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Section className="bg-primary text-white">
+        <div className="d-flex flex-wrap align-items-center justify-content-between mb-0">
+          <h2 className="h4 mb-0">Instructor</h2>
+          <Form.Checkbox checked readOnly className="mb-0 text-white">
+            New Instructor outside FBR
+          </Form.Checkbox>
+        </div>
+      </Card.Section>
+      <Card.Section>
+        {errorCount > 0 && (
+          <Alert variant="danger" dismissible={false} show>
+            Please complete {errorCount === 1 ? 'this field' : `${errorCount} fields`} before saving.
+          </Alert>
+        )}
+        {showSavedMessage && (
+          <Alert variant="success" dismissible={false} show>
+            Instructor details saved.
+          </Alert>
+        )}
+        {saveError && (
+          <Alert variant="danger" dismissible={false} show>
+            {saveError}
+          </Alert>
+        )}
+        <Form onSubmit={handleSubmit}>
+          <div className="row">
+            {FORM_FIELDS.map((field) => (
+              <Form.Group key={field.key} className="col-md-6 mb-3">
+                <Form.Label htmlFor={`outside-hrms-${field.key}`}>{field.label}</Form.Label>
+                <Form.Control
+                  id={`outside-hrms-${field.key}`}
+                  type={field.type}
+                  value={formValue[field.key]}
+                  isInvalid={Boolean(errors[field.key])}
+                  onChange={(event) => handleChange(field.key, event.target.value)}
+                />
+                {errors[field.key] && (
+                  <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
+                    {errors[field.key]}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+            ))}
+          </div>
+          <Button type="submit" variant="primary" disabled={isSaving}>
+            {isSaving ? 'Saving...' : 'Save'}
+          </Button>
+        </Form>
+      </Card.Section>
+    </Card>
+  );
+};
+
+OutsideHrmsInstructorForm.propTypes = {
+  onComplete: PropTypes.func,
+  username: PropTypes.string,
+};
+
+OutsideHrmsInstructorForm.defaultProps = {
+  onComplete: () => {},
+  username: null,
+};
+
+export default OutsideHrmsInstructorForm;


### PR DESCRIPTION
## Summary

This PR implements the required profile completion flow for biodata users.

## Changes

- Replaces the biodata accordion layout with a stepper-style section flow.
- Adds section completion, validation, error summaries, and “Save and Next” behavior.
- Blocks navigation away from the required profile flow until completion, while still allowing logout.
- Adds file upload, preview, replace, and remove support for biodata attachments.
- Adds backend mapping and multipart payload support for biodata file fields.
- Expands biodata API config for submission state, repeatable sections, extra fields, and new attachment fields.
- Adds handling for CSS service preferences, compulsory CSS subject marks, employment first-job logic, siblings, and declaration completion.
- Adds an outside-HRMS instructor form path for non-admin authenticated users.
- Fetches and stores profile completion status with the profile page data.
- Updates profile page snapshots.

## Screenshots and Recording

<img width="1674" height="875" alt="Screenshot 2026-04-21 at 6 30 04 PM" src="https://github.com/user-attachments/assets/c26663e8-108c-40cd-be36-ab51fc13f5f4" />

<img width="1721" height="918" alt="Screenshot 2026-04-21 at 6 30 42 PM" src="https://github.com/user-attachments/assets/c05f7a24-3e68-45b3-911a-217daa342375" />

<img width="1812" height="912" alt="Screenshot 2026-04-21 at 7 04 11 PM" src="https://github.com/user-attachments/assets/69286ddd-5816-4ba5-b76e-175d3a811eda" />

https://github.com/user-attachments/assets/411b615d-d017-40fa-b87e-b6c4bdf260da

