### PR TITLE
feat: Biodata Draft auto-save, Stepper UI improvements, and OutsideHRMS CNIC Attachments

### DIFF
--- a/src/profile/biodata/BiodataProfileSections.jsx
+++ b/src/profile/biodata/BiodataProfileSections.jsx
@@ -4,13 +4,13 @@ import React, {
 import { useDispatch, useSelector } from 'react-redux';
 import { Card, Nav } from '@openedx/paragon';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { faCheck, faExclamation } from '@fortawesome/free-solid-svg-icons';
+import { faCheckCircle, faExclamationCircle } from '@fortawesome/free-solid-svg-icons';
 import classNames from 'classnames';
 
 import { BIODATA_SECTIONS } from './config';
 import BiodataSection from './BiodataSection';
 import {
-  closeForm, saveProfile, saveProfileFailure, updateDraft,
+  closeForm, saveProfile, saveProfileFailure, saveDraftSection, updateDraft,
 } from '../data/actions';
 import {
   BIODATA_DATE_VALIDATION_MESSAGES,
@@ -104,6 +104,38 @@ const getStepStatusLabel = (stepState, isActive) => {
   return isActive ? 'Current' : 'Not started';
 };
 
+const renderStepStatusIcon = (stepState, isActive) => {
+  if (stepState.error) {
+    return (
+      <FontAwesomeIcon
+        icon={faExclamationCircle}
+        className={isActive ? 'text-white' : 'text-danger'}
+        style={{ fontSize: '1.25rem' }}
+      />
+    );
+  }
+  if (stepState.completed) {
+    return (
+      <FontAwesomeIcon
+        icon={faCheckCircle}
+        className={isActive ? 'text-white' : 'text-success'}
+        style={{ fontSize: '1.25rem' }}
+      />
+    );
+  }
+  return (
+    <span
+      className={classNames(
+        'd-inline-block rounded-circle',
+        isActive ? 'bg-white' : 'bg-gray-400',
+      )}
+      style={{ fontSize: '1.25rem', width: '0.95rem', height: '0.95rem' }}
+    />
+  );
+};
+
+const getBiodataDraftStorageKey = (username, sectionId) => `fbr.biodata.draft:${username}:${sectionId}`;
+
 const isTruthyFlag = value => value === true || String(value || '').trim().toLowerCase() === 'true';
 
 const getSectionCompletedState = (section, savedData) => sectionIsComplete(section, savedData);
@@ -130,6 +162,7 @@ const BiodataProfileSections = () => {
   const accountUsername = account?.username;
   const previousSaveState = useRef(saveState);
   const hasResolvedInitialStep = useRef(false);
+  const hasDraftRestoreRef = useRef(false);
   const [pendingSaveStepId, setPendingSaveStepId] = useState(null);
   const stepperSections = useMemo(() => getStepperSections(BIODATA_SECTIONS), []);
   const [activeStepId, setActiveStepId] = useState(stepperSections[0].id);
@@ -173,7 +206,25 @@ const BiodataProfileSections = () => {
 
   useEffect(() => {
     hasResolvedInitialStep.current = false;
+    hasDraftRestoreRef.current = false;
   }, [accountUsername]);
+
+  useEffect(() => {
+    if (!accountUsername || hasDraftRestoreRef.current || visibleSections.length === 0) {
+      return;
+    }
+    hasDraftRestoreRef.current = true;
+    visibleSections.forEach((section) => {
+      try {
+        const stored = localStorage.getItem(getBiodataDraftStorageKey(accountUsername, section.id));
+        if (stored) {
+          dispatch(updateDraft(section.id, JSON.parse(stored)));
+        }
+      } catch (e) {
+        // ignore parse/storage errors
+      }
+    });
+  }, [accountUsername, dispatch, visibleSections]);
 
   useEffect(() => {
     if (!accountUsername || hasResolvedInitialStep.current || visibleSections.length === 0) {
@@ -242,6 +293,13 @@ const BiodataProfileSections = () => {
           error: false,
         },
       }));
+      if (accountUsername) {
+        try {
+          localStorage.removeItem(getBiodataDraftStorageKey(accountUsername, pendingSaveStepId));
+        } catch (e) {
+          // ignore
+        }
+      }
       const nextSectionId = pendingReturnSectionId
         || getNextIncompleteVisibleSectionId(
           visibleSections,
@@ -273,7 +331,10 @@ const BiodataProfileSections = () => {
       setPendingScrollSectionId(pendingSaveStepId);
       setPendingSaveStepId(null);
     }
-  }, [drafts, errors, extendedProfile, pendingReturnSectionId, pendingSaveStepId, saveState, visibleSections]);
+  }, [
+    accountUsername, drafts, errors, extendedProfile,
+    pendingReturnSectionId, pendingSaveStepId, saveState, visibleSections,
+  ]);
 
   if (!accountUsername || !activeSection) {
     return null;
@@ -354,9 +415,21 @@ const BiodataProfileSections = () => {
       if (incompleteSection) {
         markSectionNeedsAttention(incompleteSection);
         setPendingReturnSectionId(sectionId);
-        moveToSection(incompleteSection.id);
+        setActiveStepId(incompleteSection.id);
+        window.setTimeout(() => {
+          document.getElementById(`biodata-section-${incompleteSection.id}`)
+            ?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+        }, 50);
         return;
       }
+    }
+
+    if (
+      sectionId !== activeSection.id
+      && drafts[activeSection.id]
+      && accountUsername
+    ) {
+      dispatch(saveDraftSection(activeSection.id, accountUsername));
     }
 
     setPendingReturnSectionId(null);
@@ -374,6 +447,14 @@ const BiodataProfileSections = () => {
     const hasDateValidationErrors = Object.keys(dateValidationErrors).length > 0;
 
     dispatch(updateDraft(sectionId, sanitizedData));
+
+    if (accountUsername) {
+      try {
+        localStorage.setItem(getBiodataDraftStorageKey(accountUsername, sectionId), JSON.stringify(sanitizedData));
+      } catch (e) {
+        // storage quota exceeded — ignore
+      }
+    }
 
     if (!section) {
       return;
@@ -462,69 +543,46 @@ const BiodataProfileSections = () => {
       <div className="col-lg-3 mb-4 mb-lg-0">
         <Card className="position-lg-sticky" style={{ top: '0' }}>
           <Card.Section>
-            <Nav variant="pills" className="flex-column">
+            <Nav variant="pills" className="flex-column biodata-stepper">
               {visibleSections.map((section, index) => {
                 const isActive = activeSection.id === section.id;
                 const isLastVisibleStep = index === visibleSections.length - 1;
                 const stepState = stepStateById[section.id] || {};
                 const statusLabel = getStepStatusLabel(stepState, isActive);
-                const savedData = getSectionInitialData(section, extendedProfile);
 
                 return (
                   <Nav.Item key={section.id}>
                     <Nav.Link
                       active={isActive}
                       data-biodata-nav={section.id}
-                      className={classNames(
-                        'mb-2 d-flex align-items-stretch text-left position-relative',
-                        { 'border border-danger': stepState.error && !isActive },
-                      )}
+                      aria-label={`${section.title}: ${statusLabel}`}
+                      className="mb-2 d-flex align-items-stretch text-left position-relative"
                       onClick={() => handleStepClick(section.id)}
                     >
-                      <span className="d-flex flex-column align-items-center flex-shrink-0 mr-2" aria-hidden="true">
+                      <span className="d-flex flex-column align-items-center flex-shrink-0 mr-2 position-relative" aria-hidden="true">
                         <span
                           className={classNames(
                             'd-inline-flex align-items-center justify-content-center flex-shrink-0',
-                            {
-                              'text-primary': isActive && !stepState.error,
-                              'text-success': stepState.completed && !isActive && !stepState.error,
-                              'text-danger': stepState.error,
-                              'text-gray-700': !isActive && !stepState.completed && !stepState.error,
-                            },
+                            isActive ? 'bg-primary' : 'bg-white',
                           )}
-                          style={{ width: '1.25rem', minHeight: '1.75rem', zIndex: 1 }}
+                          style={{ width: '1.75rem', minHeight: '1.75rem', zIndex: 1 }}
                         >
-                          {stepState.error && <FontAwesomeIcon icon={faExclamation} size="sm" />}
-                          {!stepState.error && stepState.completed && <FontAwesomeIcon icon={faCheck} size="sm" />}
-                          {!stepState.error && !stepState.completed && (
-                            <span
-                              className={classNames(
-                                'd-inline-block rounded-circle',
-                                isActive ? 'bg-primary' : 'bg-gray-700',
-                              )}
-                              style={{ width: '0.5rem', height: '0.5rem' }}
-                            />
-                          )}
+                          {renderStepStatusIcon(stepState, isActive)}
                         </span>
                         {!isLastVisibleStep && (
                           <span
                             className={classNames(
-                              'border-left flex-grow-1 mt-1 mb-n2',
-                              stepState.completed && !stepState.error ? 'border-success' : 'border-light-500',
+                              'biodata-stepper__connector',
+                              {
+                                'biodata-stepper__connector--completed': stepState.completed && !stepState.error && !isActive,
+                                'biodata-stepper__connector--error': stepState.error && !isActive,
+                                'biodata-stepper__connector--active': isActive,
+                              },
                             )}
-                            style={{ minHeight: '1.25rem' }}
                           />
                         )}
                       </span>
-                      <span className="pb-2">
-                        <span className="font-weight-bold d-block">{section.title}</span>
-                        <span className={classNames('small d-block', stepState.error ? 'text-danger' : 'text-muted')}>
-                          {statusLabel}
-                        </span>
-                        {!sectionHasValue(section, savedData) && !stepState.completed && !stepState.error && (
-                          <span className="small text-muted d-block">No information added</span>
-                        )}
-                      </span>
+                      <span className="font-weight-bold">{section.title}</span>
                     </Nav.Link>
                   </Nav.Item>
                 );
@@ -537,7 +595,7 @@ const BiodataProfileSections = () => {
         <Card id={`biodata-section-${activeSection.id}`} className="shadow-sm">
           <Card.Section>
             <div className="mb-3">
-              <div className="font-weight-bold text-gray-900 h5 mb-1">{activeSection.title}</div>
+              <div className="font-weight-bold text-gray-900 h3 mb-1">{activeSection.title}</div>
               {activeSection.helperText && (
                 <div className="small text-muted">{activeSection.helperText}</div>
               )}

--- a/src/profile/data/actions.js
+++ b/src/profile/data/actions.js
@@ -137,3 +137,21 @@ export const updateDraft = (name, value) => ({
 export const resetDrafts = () => ({
   type: RESET_DRAFTS,
 });
+
+export const SAVE_DRAFT_SECTION = new AsyncActionType('PROFILE', 'SAVE_DRAFT_SECTION');
+export const RESET_SECTION_DRAFT = 'RESET_SECTION_DRAFT';
+
+export const saveDraftSection = (formId, username) => ({
+  type: SAVE_DRAFT_SECTION.BASE,
+  payload: { formId, username },
+});
+
+export const saveDraftSectionSuccess = (account) => ({
+  type: SAVE_DRAFT_SECTION.SUCCESS,
+  payload: { account },
+});
+
+export const resetSectionDraft = (sectionId) => ({
+  type: RESET_SECTION_DRAFT,
+  payload: { sectionId },
+});

--- a/src/profile/data/reducers.js
+++ b/src/profile/data/reducers.js
@@ -7,6 +7,8 @@ import {
   FETCH_PROFILE,
   UPDATE_DRAFT,
   RESET_DRAFTS,
+  SAVE_DRAFT_SECTION,
+  RESET_SECTION_DRAFT,
 } from './actions';
 
 export const initialState = {
@@ -161,6 +163,26 @@ const profilePage = (state = initialState, action = {}) => {
         ...state,
         drafts: {},
       };
+    case SAVE_DRAFT_SECTION.SUCCESS: {
+      const draftAccount = action.payload.account;
+      return {
+        ...state,
+        account: draftAccount !== null ? {
+          ...state.account,
+          ...draftAccount,
+          extendedProfile: draftAccount.extendedProfile || state.account.extendedProfile,
+          socialLinks: draftAccount.socialLinks || state.account.socialLinks,
+          languageProficiencies: draftAccount.languageProficiencies || state.account.languageProficiencies,
+        } : state.account,
+      };
+    }
+    case RESET_SECTION_DRAFT: {
+      const { [action.payload.sectionId]: _removed, ...remainingDrafts } = state.drafts;
+      return {
+        ...state,
+        drafts: remainingDrafts,
+      };
+    }
     case OPEN_FORM:
       return {
         ...state,

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -20,11 +20,14 @@ import {
   fetchProfileSuccess,
   FETCH_PROFILE,
   resetDrafts,
+  resetSectionDraft,
   saveProfileBegin,
   saveProfileFailure,
   saveProfileReset,
   saveProfileSuccess,
   SAVE_PROFILE,
+  saveDraftSectionSuccess,
+  SAVE_DRAFT_SECTION,
   saveProfilePhotoBegin,
   saveProfilePhotoReset,
   saveProfilePhotoSuccess,
@@ -185,7 +188,11 @@ export function* handleSaveProfile(action) {
     yield put(closeForm(action.payload.formId));
     yield delay(300);
     yield put(saveProfileReset());
-    yield put(resetDrafts());
+    if (biodataSection) {
+      yield put(resetSectionDraft(action.payload.formId));
+    } else {
+      yield put(resetDrafts());
+    }
   } catch (e) {
     if (e.processedData && e.processedData.fieldErrors) {
       yield put(saveProfileFailure(e.processedData.fieldErrors));
@@ -193,6 +200,33 @@ export function* handleSaveProfile(action) {
       yield put(saveProfileReset());
       throw e;
     }
+  }
+}
+
+export function* handleSaveDraftSection(action) {
+  try {
+    const { drafts, account } = yield select(handleSaveProfileSelector);
+    const sectionDraft = drafts[action.payload.formId];
+    if (!sectionDraft) {
+      return;
+    }
+
+    const committedSectionData = buildSectionDraftFromExtendedProfile(
+      action.payload.formId,
+      account.extendedProfile || [],
+    );
+
+    const result = yield call(
+      ProfileApiService.saveBiodataSection,
+      action.payload.formId,
+      sectionDraft,
+      committedSectionData,
+      account.extendedProfile || [],
+    );
+
+    yield put(saveDraftSectionSuccess(result));
+  } catch (e) {
+    // silent — draft saves are best-effort; localStorage is the fallback
   }
 }
 
@@ -225,6 +259,7 @@ export function* handleDeleteProfilePhoto(action) {
 export default function* profileSaga() {
   yield takeEvery(FETCH_PROFILE.BASE, handleFetchProfile);
   yield takeEvery(SAVE_PROFILE.BASE, handleSaveProfile);
+  yield takeEvery(SAVE_DRAFT_SECTION.BASE, handleSaveDraftSection);
   yield takeEvery(SAVE_PROFILE_PHOTO.BASE, handleSaveProfilePhoto);
   yield takeEvery(DELETE_PROFILE_PHOTO.BASE, handleDeleteProfilePhoto);
 }

--- a/src/profile/forms/outside-hrms/OutsideHrmsInstructorForm.jsx
+++ b/src/profile/forms/outside-hrms/OutsideHrmsInstructorForm.jsx
@@ -1,10 +1,12 @@
-import React, { useMemo, useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Button, Card, Form,
 } from '@openedx/paragon';
 
 import { saveOutsideHrmsInstructorProfile } from '../../data/services';
+import { BiodataFileActions, BiodataFilePreview } from '../../biodata/BiodataFilePreview';
+import { createFileUploadValue, getFileUploadBlob, revokeFilePreviewUrl } from '../../biodata/utils';
 
 const INITIAL_FORM_VALUE = {
   name: '',
@@ -16,6 +18,7 @@ const INITIAL_FORM_VALUE = {
   expertise: '',
   organization: '',
   email: '',
+  cnic: '',
 };
 
 const FORM_FIELDS = [
@@ -28,21 +31,54 @@ const FORM_FIELDS = [
   { key: 'expertise', label: 'Expertise', type: 'text' },
   { key: 'organization', label: 'Organization', type: 'text' },
   { key: 'email', label: 'Email', type: 'email' },
+  { key: 'cnic', label: 'CNIC', type: 'text' },
 ];
 
-const getRequiredErrors = (formValue) => FORM_FIELDS.reduce((accumulator, field) => {
-  if (!String(formValue[field.key] || '').trim()) {
-    accumulator[field.key] = `${field.label} is required.`;
-  }
-  return accumulator;
-}, {});
+const CNIC_FILE_FIELDS = [
+  { key: 'cnicFront', label: 'CNIC Front' },
+  { key: 'cnicBack', label: 'CNIC Back' },
+];
+
+const ACCEPTED_IMAGE_TYPES = 'image/jpeg,image/png,image/webp,application/pdf';
+
+const INITIAL_CNIC_FILES = { cnicFront: null, cnicBack: null };
+
+const getRequiredErrors = (formValue, cnicFiles) => {
+  const fieldErrors = FORM_FIELDS.reduce((accumulator, field) => {
+    if (!String(formValue[field.key] || '').trim()) {
+      accumulator[field.key] = `${field.label} is required.`;
+    }
+    return accumulator;
+  }, {});
+
+  CNIC_FILE_FIELDS.forEach(({ key, label }) => {
+    if (!cnicFiles[key]) {
+      fieldErrors[key] = `${label} is required.`;
+    }
+  });
+
+  return fieldErrors;
+};
+
+const fileToBase64 = file => new Promise((resolve, reject) => {
+  const reader = new FileReader();
+  reader.onload = () => resolve(reader.result);
+  reader.onerror = reject;
+  reader.readAsDataURL(file);
+});
 
 const OutsideHrmsInstructorForm = ({ onComplete, username }) => {
   const [formValue, setFormValue] = useState(INITIAL_FORM_VALUE);
+  const [cnicFiles, setCnicFiles] = useState(INITIAL_CNIC_FILES);
   const [errors, setErrors] = useState({});
   const [showSavedMessage, setShowSavedMessage] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [saveError, setSaveError] = useState('');
+
+  const cnicFrontInputRef = useRef(null);
+  const cnicBackInputRef = useRef(null);
+  const fileInputRefs = { cnicFront: cnicFrontInputRef, cnicBack: cnicBackInputRef };
+
   const errorCount = useMemo(() => Object.keys(errors).length, [errors]);
 
   const handleChange = (fieldName, value) => {
@@ -59,10 +95,37 @@ const OutsideHrmsInstructorForm = ({ onComplete, username }) => {
     setSaveError('');
   };
 
+  const handleFileSelect = (fieldKey, file) => {
+    if (!file) {
+      return;
+    }
+    setCnicFiles((prev) => {
+      revokeFilePreviewUrl(prev[fieldKey]);
+      return { ...prev, [fieldKey]: createFileUploadValue(file) };
+    });
+    setErrors(previousErrors => {
+      const nextErrors = { ...previousErrors };
+      delete nextErrors[fieldKey];
+      return nextErrors;
+    });
+    setShowSavedMessage(false);
+    setSaveError('');
+    if (fileInputRefs[fieldKey]?.current) {
+      fileInputRefs[fieldKey].current.value = '';
+    }
+  };
+
+  const handleFileRemove = (fieldKey) => {
+    setCnicFiles((prev) => {
+      revokeFilePreviewUrl(prev[fieldKey]);
+      return { ...prev, [fieldKey]: null };
+    });
+  };
+
   const handleSubmit = async (event) => {
     event.preventDefault();
 
-    const nextErrors = getRequiredErrors(formValue);
+    const nextErrors = getRequiredErrors(formValue, cnicFiles);
     if (Object.keys(nextErrors).length > 0) {
       setErrors(nextErrors);
       setShowSavedMessage(false);
@@ -74,8 +137,29 @@ const OutsideHrmsInstructorForm = ({ onComplete, username }) => {
     setSaveError('');
 
     try {
-      const completionStatus = await saveOutsideHrmsInstructorProfile(formValue, username);
+      const frontBlob = getFileUploadBlob(cnicFiles.cnicFront);
+      const backBlob = getFileUploadBlob(cnicFiles.cnicBack);
+
+      const [cnicFrontBase64, cnicBackBase64] = await Promise.all([
+        fileToBase64(frontBlob),
+        fileToBase64(backBlob),
+      ]);
+
+      const completionStatus = await saveOutsideHrmsInstructorProfile(
+        {
+          ...formValue,
+          cnicFrontAttachment: cnicFrontBase64,
+          cnicFrontAttachmentName: cnicFiles.cnicFront.name,
+          cnicBackAttachment: cnicBackBase64,
+          cnicBackAttachmentName: cnicFiles.cnicBack.name,
+        },
+        username,
+      );
+
+      revokeFilePreviewUrl(cnicFiles.cnicFront);
+      revokeFilePreviewUrl(cnicFiles.cnicBack);
       setFormValue(INITIAL_FORM_VALUE);
+      setCnicFiles(INITIAL_CNIC_FILES);
       setErrors({});
       setShowSavedMessage(true);
       onComplete(completionStatus);
@@ -128,6 +212,33 @@ const OutsideHrmsInstructorForm = ({ onComplete, username }) => {
                 {errors[field.key] && (
                   <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
                     {errors[field.key]}
+                  </Form.Control.Feedback>
+                )}
+              </Form.Group>
+            ))}
+
+            {CNIC_FILE_FIELDS.map(({ key, label }) => (
+              <Form.Group key={key} className="col-md-6 mb-3">
+                <Form.Label>{label}</Form.Label>
+                <input
+                  type="file"
+                  accept={ACCEPTED_IMAGE_TYPES}
+                  ref={fileInputRefs[key]}
+                  className="d-none"
+                  onChange={(event) => handleFileSelect(key, event.target.files[0] || null)}
+                />
+                <div className={errors[key] ? 'border border-danger rounded p-2' : ''}>
+                  <BiodataFileActions
+                    field={{ label }}
+                    fileValue={cnicFiles[key]}
+                    onReplace={() => fileInputRefs[key].current?.click()}
+                    onRemove={() => handleFileRemove(key)}
+                  />
+                  <BiodataFilePreview field={{ label }} fileValue={cnicFiles[key]} />
+                </div>
+                {errors[key] && (
+                  <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
+                    {errors[key]}
                   </Form.Control.Feedback>
                 )}
               </Form.Group>

--- a/src/profile/index.scss
+++ b/src/profile/index.scss
@@ -259,3 +259,27 @@
 .overflowWrap-breakWord {
   overflow-wrap: break-word;
 }
+
+.biodata-stepper {
+  .biodata-stepper__connector {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 3px;
+    top: 1.475rem;
+    bottom: -1.775rem;
+    background-color: var(--pgn-color-gray-200);
+
+    &.biodata-stepper__connector--completed {
+      background-color: var(--pgn-color-success-base);
+    }
+
+    &.biodata-stepper__connector--error {
+      background-color: var(--pgn-color-danger-base);
+    }
+
+    &.biodata-stepper__connector--active {
+      background-color: var(--pgn-color-primary-500);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Biodata draft auto-save:** In-progress biodata section data is now persisted both in localStorage (for page refreshes) and server-side (via a new `SAVE_DRAFT_SECTION` saga triggered on navigation). Drafts are restored on load and cleared individually after each section save, so work in other sections is never lost.
- **Stepper sidebar refinements:** Replaced plain FA icons with `faCheckCircle`/`faExclamationCircle` for cleaner state signalling. Redesigned the vertical connector using absolute CSS positioning with state-based modifier classes (`--completed`, `--error`, `--active`). Added solid background to icon wrappers to prevent connector bleed-through.
- **Declaration navigation scroll fix:** When clicking the Declaration step with incomplete sections, the page now reliably scrolls to the first incomplete form using a direct `scrollIntoView` with a short timeout, replacing the flaky `pendingScrollSectionId` mechanism.
- **OutsideHRMS CNIC fields:** Added a CNIC number text field and CNIC front/back file attachment fields to the outside-HRMS instructor form.

## Test Plan

- [X] Fill a biodata section partially, navigate to another section — verify draft is restored on return
- [X] Refresh the page mid-form — verify draft is restored from localStorage
- [X] Save a section — verify only that section's draft is cleared; other sections' data is intact
- [X] Click the Declaration step with incomplete sections — verify the page scrolls to the first incomplete form
- [X] Verify stepper connector colors: gray (not started), blue (active), green (completed), red (error); no connector bleed-through on adjacent icons
- [X] Submit the OutsideHRMS instructor form with all CNIC fields filled — verify upload succeeds

## Screenshots

### Biodata Form

| Before | After |
|--------|-------|
| <img width="420" alt="Biodata Form Before" src="https://github.com/user-attachments/assets/49f4fe04-bd68-4039-8cb6-a659596b62f5" /> | <img width="420" alt="Biodata Form After" src="https://github.com/user-attachments/assets/60a5c1bf-315a-4ece-9cc0-e26b6ddcfc7a" /> |

> **Note:** The stepper connector looks slightly weird in the screenshot, but it appears correctly on the local server.

### OutsideHRMS Form

| Before | After |
|--------|-------|
| <img width="420" alt="OutsideHRMS Form Before" src="https://github.com/user-attachments/assets/367df765-edc5-4dd6-9bf3-84d1f9dc935f" /> | <img width="420" alt="OutsideHRMS Form After" src="https://github.com/user-attachments/assets/463eb09b-4900-44f1-aa62-38328733006b" /> |