### PR TITLE
Fix row-scoped validation for CSS subject marks repeatable fields

### DIFF
--- a/src/profile/biodata/BiodataSection.jsx
+++ b/src/profile/biodata/BiodataSection.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useRef } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import {
   Alert, Button, Form, StatefulButton,
@@ -12,6 +14,8 @@ import RepeatableFieldGroup from './RepeatableFieldGroup';
 import {
   createFileUploadValue,
   createEmptyRepeatableRow,
+  getRepeatableFieldErrorKey,
+  getRepeatableFieldValidationError,
   getSectionError,
   getSectionErrorFields,
   getSectionErrorSummary,
@@ -163,10 +167,12 @@ const BiodataSection = ({
   );
   const formDataRef = useRef(formData);
   const sectionRef = useRef(section);
+  const [localErrors, setLocalErrors] = useState({});
+  const mergedErrors = useMemo(() => ({ ...errors, ...localErrors }), [errors, localErrors]);
   const hasContent = sectionHasValue(section, committedData);
-  const sectionError = getSectionError(section, errors);
-  const sectionErrorSummary = getSectionErrorSummary(section, errors, formData);
-  const sectionErrorFields = getSectionErrorFields(section, errors, formData);
+  const sectionError = getSectionError(section, mergedErrors);
+  const sectionErrorSummary = getSectionErrorSummary(section, mergedErrors, formData);
+  const sectionErrorFields = getSectionErrorFields(section, mergedErrors, formData);
 
   useEffect(() => {
     formDataRef.current = formData;
@@ -176,6 +182,10 @@ const BiodataSection = ({
   useEffect(() => () => {
     revokeSectionFilePreviews(sectionRef.current, formDataRef.current);
   }, []);
+
+  useEffect(() => {
+    setLocalErrors({});
+  }, [section.id]);
 
   if (!isAuthenticatedUserProfile && !hasContent) {
     return null;
@@ -232,9 +242,20 @@ const BiodataSection = ({
       ) {
         return;
       }
+      const currentRow = currentRows[payload.rowIndex];
+      const currentFieldErrorKey = getRepeatableFieldErrorKey(repeatable, currentRow, payload.columnKey);
       nextRows = currentRows.map((row, index) => (
         index === payload.rowIndex ? { ...row, [payload.columnKey]: payload.value } : row
       ));
+      setLocalErrors((previousErrors) => {
+        if (!previousErrors[currentFieldErrorKey]) {
+          return previousErrors;
+        }
+
+        const nextErrors = { ...previousErrors };
+        delete nextErrors[currentFieldErrorKey];
+        return nextErrors;
+      });
     }
 
     nextRows = normalizeRepeatableRows(nextRows, repeatable);
@@ -242,6 +263,32 @@ const BiodataSection = ({
     onDraftChange(section.id, {
       ...formData,
       [repeatable.storageFieldName]: nextRows,
+    });
+  };
+
+  const handleRepeatableFieldBlur = (repeatable, rowIndex, columnKey) => {
+    const row = (formData[repeatable.storageFieldName] || [])[rowIndex];
+    const column = repeatable.columns.find(item => item.key === columnKey);
+
+    if (!row || !column) {
+      return;
+    }
+
+    const fieldErrorKey = getRepeatableFieldErrorKey(repeatable, row, columnKey);
+    const fieldValidationError = getRepeatableFieldValidationError(repeatable, row, column);
+
+    setLocalErrors((previousErrors) => {
+      const nextErrors = { ...previousErrors };
+
+      if (fieldValidationError) {
+        nextErrors[fieldErrorKey] = {
+          userMessage: fieldValidationError.userMessage,
+        };
+      } else {
+        delete nextErrors[fieldErrorKey];
+      }
+
+      return nextErrors;
     });
   };
 
@@ -297,7 +344,7 @@ const BiodataSection = ({
       )}
       <div className="row">
         {visibleFields.map((field) => {
-          const error = errors[field.fieldName];
+          const error = mergedErrors[field.fieldName];
           return (
             <Form.Group
               key={field.fieldName}
@@ -339,8 +386,9 @@ const BiodataSection = ({
           <RepeatableFieldGroup
             repeatable={repeatable}
             rows={formData[repeatable.storageFieldName] || [createEmptyRepeatableRow(repeatable)]}
-            errors={errors}
+            errors={mergedErrors}
             onChange={(action, payload) => handleRepeatableChange(repeatable, action, payload)}
+            onBlur={(rowIndex, columnKey) => handleRepeatableFieldBlur(repeatable, rowIndex, columnKey)}
             disabled={
               disabled
               || isSectionDisabled
@@ -351,7 +399,7 @@ const BiodataSection = ({
       ))}
       {(section.fileFields || []).map((field) => {
         const fileValue = formData[field.fieldName];
-        const error = errors[field.fieldName];
+        const error = mergedErrors[field.fieldName];
         if (disabled || isSectionDisabled) {
           return <div key={field.fieldName}>{renderReadonlyFile(field, fileValue)}</div>;
         }

--- a/src/profile/biodata/RepeatableFieldGroup.jsx
+++ b/src/profile/biodata/RepeatableFieldGroup.jsx
@@ -12,7 +12,7 @@ import {
   revokeFilePreviewUrl,
 } from './utils';
 
-function renderControl(field, value, onChange, error, disabled = false) {
+function renderControl(field, value, onChange, onBlur, error, disabled = false) {
   if (field.type === PROFILE_FIELD_TYPES.FILE) {
     const inputId = field.inputId || field.key;
     return (
@@ -60,6 +60,7 @@ function renderControl(field, value, onChange, error, disabled = false) {
         value={value}
         isInvalid={Boolean(error)}
         disabled={disabled}
+        onBlur={onBlur}
         onChange={(event) => onChange(event.target.value)}
       >
         {(field.options || []).map((option) => (
@@ -80,6 +81,7 @@ function renderControl(field, value, onChange, error, disabled = false) {
         placeholder={field.placeholder}
         isInvalid={Boolean(error)}
         disabled={disabled}
+        onBlur={onBlur}
         onChange={(event) => onChange(event.target.value)}
       />
     );
@@ -92,6 +94,7 @@ function renderControl(field, value, onChange, error, disabled = false) {
       placeholder={field.placeholder}
       isInvalid={Boolean(error)}
       disabled={disabled}
+      onBlur={onBlur}
       onChange={(event) => onChange(event.target.value)}
     />
   );
@@ -102,6 +105,7 @@ const RepeatableFieldGroup = ({
   rows,
   errors,
   onChange,
+  onBlur,
   disabled,
 }) => (
   <div>
@@ -126,7 +130,7 @@ const RepeatableFieldGroup = ({
           </div>
           <div className="row">
             {repeatable.columns.map((column) => {
-              const error = errors[getRepeatableFieldErrorKey(repeatable, row, column.key)] || errors[column.key];
+              const error = errors[getRepeatableFieldErrorKey(repeatable, row, column.key)];
               const controlField = {
                 ...column,
                 inputId: `${row.rowId}-${column.key}`,
@@ -144,7 +148,7 @@ const RepeatableFieldGroup = ({
                     rowIndex,
                     columnKey: column.key,
                     value,
-                  }), error, isControlDisabled)}
+                  }), () => onBlur(rowIndex, column.key), error, isControlDisabled)}
                   {!isControlDisabled && error && error.userMessage && (
                     <Form.Control.Feedback hasIcon={false} className="d-block text-danger small mt-1">
                       {error.userMessage}
@@ -195,11 +199,13 @@ RepeatableFieldGroup.propTypes = {
     PropTypes.string,
   ])),
   onChange: PropTypes.func.isRequired,
+  onBlur: PropTypes.func,
   disabled: PropTypes.bool,
 };
 
 RepeatableFieldGroup.defaultProps = {
   errors: {},
+  onBlur: () => {},
   disabled: false,
 };
 

--- a/src/profile/biodata/utils.js
+++ b/src/profile/biodata/utils.js
@@ -710,6 +710,46 @@ function validateFieldFormat(field, value) {
   return '';
 }
 
+export function getRepeatableFieldValidationError(repeatable, row, column) {
+  const value = row?.[column.key];
+
+  if (column.type === PROFILE_FIELD_TYPES.FILE) {
+    if (!value) {
+      return getRepeatableFieldError(repeatable, row, column.key, `Upload ${column.label}.`);
+    }
+    return null;
+  }
+
+  if (!hasFieldValue(value)) {
+    return getRepeatableFieldError(
+      repeatable,
+      row,
+      column.key,
+      getRequiredFieldMessage(column.label),
+    );
+  }
+
+  const formatError = validateFieldFormat(
+    {
+      ...column,
+      fieldName: column.key,
+    },
+    value,
+  );
+  if (formatError) {
+    return getRepeatableFieldError(repeatable, row, column.key, formatError);
+  }
+
+  if (column.validate) {
+    const customError = column.validate(value, row);
+    if (customError) {
+      return getRepeatableFieldError(repeatable, row, column.key, customError);
+    }
+  }
+
+  return null;
+}
+
 function validateEducationRowDateRules(repeatable, row) {
   const validationErrors = {};
   const attendedFrom = String(row.attended_from || '').trim();
@@ -842,43 +882,11 @@ export function validateSectionDraft(section, sectionData) {
 
     rows.forEach((row) => {
       repeatable.columns.forEach((column) => {
-        const value = row[column.key];
-
-        if (column.type === PROFILE_FIELD_TYPES.FILE) {
-          if (!value) {
-            validationErrors[column.key] = {
-              userMessage: `Upload ${column.label}.`,
-            };
-          }
-          return;
-        }
-
-        if (!hasFieldValue(value)) {
-          validationErrors[column.key] = {
-            userMessage: getRequiredFieldMessage(column.label),
+        const repeatableFieldError = getRepeatableFieldValidationError(repeatable, row, column);
+        if (repeatableFieldError) {
+          validationErrors[repeatableFieldError.fieldName] = {
+            userMessage: repeatableFieldError.userMessage,
           };
-          return;
-        }
-
-        const formatError = validateFieldFormat(
-          {
-            ...column,
-            fieldName: column.key,
-          },
-          value,
-        );
-        if (formatError) {
-          validationErrors[column.key] = {
-            userMessage: formatError,
-          };
-          return;
-        }
-
-        if (column.validate) {
-          const customError = column.validate(value, row);
-          if (customError) {
-            validationErrors[column.key] = { userMessage: customError };
-          }
         }
       });
     });
@@ -1167,6 +1175,15 @@ export function getSectionError(section, errors) {
   const repeatableError = (section.repeatables || []).find((repeatable) => errors[repeatable.storageFieldName]);
   if (repeatableError) {
     return errors[repeatableError.storageFieldName];
+  }
+
+  const repeatableFieldErrorKey = Object.keys(errors).find((errorFieldName) => (
+    (section.repeatables || []).some((repeatable) => (
+      errorFieldName.startsWith(`${repeatable.storageFieldName}.`)
+    ))
+  ));
+  if (repeatableFieldErrorKey) {
+    return errors[repeatableFieldErrorKey];
   }
 
   const fileError = (section.fileFields || []).find((field) => errors[field.fieldName]);


### PR DESCRIPTION
## Summary

Fix validation behavior in the Biodata CSS subject marks repeatable section so the `marks_obtained > total_marks` rule is scoped to the affected row only.

## Changes

- store repeatable validation errors using row-specific keys instead of shared column keys
- remove the shared repeatable error fallback that caused valid rows to show the same error
- add runtime blur validation for repeatable fields in the Biodata section UI
- validate `marks_obtained` on blur and show the existing message only on the affected row
- keep the existing API payload structure and leave unrelated repeatable sections unchanged

## Expected Behavior

- if Subject mark 1 has total marks `100` and marks obtained `120`, only Subject mark 1 shows `Marks obtained cannot exceed total marks.`
- if Subject mark 2 has total marks `100` and marks obtained `90`, it does not show the error
- if Subject mark 3 has total marks `100` and marks obtained `83`, it does not show the error
- the error appears when the user leaves the Marks Obtained field
