### PR TITLE
fix: Preserve Repeatable Biodata Rows on Save and Step Navigation

### DIFF
--- a/src/profile/ProfilePage.jsx
+++ b/src/profile/ProfilePage.jsx
@@ -257,6 +257,7 @@ const ProfilePage = ({ params }) => {
         <FbrProfileTabs
           profile={fbrProfile}
           showStpBiodataForm={isStpTrainee}
+          requiresStpBiodataCompletion={shouldBlockNavigation}
           onProfileUpdated={setFbrProfile}
           onStpBiodataComplete={() => {
             setCompletionOverride(true);

--- a/src/profile/ProfilePage.test.jsx
+++ b/src/profile/ProfilePage.test.jsx
@@ -133,7 +133,7 @@ describe('<ProfilePage />', () => {
   });
 
   describe('Renders correctly in various states', () => {
-    it('app loading', () => {
+    it('app loading', async () => {
       const contextValue = {
         authenticatedUser: { userId: null, username: null, administrator: false },
         config: baseTestConfig,
@@ -145,10 +145,15 @@ describe('<ProfilePage />', () => {
         />
       );
       const { container: tree } = render(component);
+
+      await waitFor(() => {
+        expect(screen.getByText('Profile loading...')).toBeInTheDocument();
+      });
+
       expect(tree).toMatchSnapshot();
     });
 
-    it('viewing own profile', () => {
+    it('viewing own profile', async () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
         config: baseTestConfig,
@@ -160,10 +165,15 @@ describe('<ProfilePage />', () => {
         />
       );
       const { container: tree } = render(component);
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Basic Information').length).toBeGreaterThan(0);
+      });
+
       expect(tree).toMatchSnapshot();
     });
 
-    it('viewing other profile with all fields', () => {
+    it('viewing other profile with all fields', async () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
         config: baseTestConfig,
@@ -200,10 +210,15 @@ describe('<ProfilePage />', () => {
         />
       );
       const { container: tree } = render(component);
+
+      await waitFor(() => {
+        expect(screen.getByText('verified')).toBeInTheDocument();
+      });
+
       expect(tree).toMatchSnapshot();
     });
 
-    it('without credentials service', () => {
+    it('without credentials service', async () => {
       const config = { ...baseTestConfig, CREDENTIALS_BASE_URL: '' };
 
       const contextValue = {
@@ -217,10 +232,15 @@ describe('<ProfilePage />', () => {
         />
       );
       const { container: tree } = render(component);
+
+      await waitFor(() => {
+        expect(screen.getAllByText('Basic Information').length).toBeGreaterThan(0);
+      });
+
       expect(tree).toMatchSnapshot();
     });
 
-    it('successfully redirected to not found page', () => {
+    it('successfully redirected to not found page', async () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
         config: baseTestConfig,
@@ -235,8 +255,12 @@ describe('<ProfilePage />', () => {
         />
       );
       const { container: tree } = render(component);
+
+      await waitFor(() => {
+        expect(navigate).toHaveBeenCalledWith('/notfound');
+      });
+
       expect(tree).toMatchSnapshot();
-      expect(navigate).toHaveBeenCalledWith('/notfound');
     });
   });
 

--- a/src/profile/ProfilePage.test.jsx
+++ b/src/profile/ProfilePage.test.jsx
@@ -49,6 +49,12 @@ const baseTestConfig = {
   LMS_BASE_URL: 'http://localhost:18000',
   ACCOUNT_SETTINGS_URL: 'http://localhost:18000/account/settings',
   LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+  DISCOVERY_API_BASE_URL: 'http://localhost:18381',
+  PUBLISHER_BASE_URL: 'http://localhost:18110',
+  IGNORED_ERROR_REGEX: '^IgnoredError',
+  LEARNING_BASE_URL: 'http://localhost:18010',
+  STUDIO_BASE_URL: 'http://localhost:18001',
+  SUPPORT_URL: 'http://localhost:18000/support',
 };
 
 Object.defineProperty(global.document, 'cookie', {

--- a/src/profile/ProfilePage.test.jsx
+++ b/src/profile/ProfilePage.test.jsx
@@ -1,4 +1,4 @@
-import { getConfig } from '@edx/frontend-platform';
+import { getConfig, setConfig } from '@edx/frontend-platform';
 import * as analytics from '@edx/frontend-platform/analytics';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import { AppContext } from '@edx/frontend-platform/react';
@@ -43,9 +43,17 @@ const requiredProfilePageProps = {
   params: { username: 'staff' },
 };
 
+const baseTestConfig = {
+  ...getConfig(),
+  CREDENTIALS_BASE_URL: 'http://localhost:18150',
+  LMS_BASE_URL: 'http://localhost:18000',
+  ACCOUNT_SETTINGS_URL: 'http://localhost:18000/account/settings',
+  LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+};
+
 Object.defineProperty(global.document, 'cookie', {
   writable: true,
-  value: `${getConfig().LANGUAGE_PREFERENCE_COOKIE_NAME}=en`,
+  value: `${baseTestConfig.LANGUAGE_PREFERENCE_COOKIE_NAME}=en`,
 });
 
 jest.mock('@edx/frontend-platform/auth', () => ({
@@ -67,12 +75,13 @@ configureI18n({
   loggingService: { logError: jest.fn() },
   config: {
     ENVIRONMENT: 'production',
-    LANGUAGE_PREFERENCE_COOKIE_NAME: 'yum',
+    LANGUAGE_PREFERENCE_COOKIE_NAME: baseTestConfig.LANGUAGE_PREFERENCE_COOKIE_NAME,
   },
   messages,
 });
 
 beforeEach(() => {
+  setConfig(baseTestConfig);
   analytics.sendTrackingLogEvent.mockReset();
   useNavigate.mockReset();
   getAuthenticatedHttpClient.mockReset();
@@ -121,7 +130,7 @@ describe('<ProfilePage />', () => {
     it('app loading', () => {
       const contextValue = {
         authenticatedUser: { userId: null, username: null, administrator: false },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       const component = (
         <ProfilePageWrapper
@@ -136,7 +145,7 @@ describe('<ProfilePage />', () => {
     it('viewing own profile', () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       const component = (
         <ProfilePageWrapper
@@ -151,7 +160,7 @@ describe('<ProfilePage />', () => {
     it('viewing other profile with all fields', () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       const component = (
         <ProfilePageWrapper
@@ -189,12 +198,11 @@ describe('<ProfilePage />', () => {
     });
 
     it('without credentials service', () => {
-      const config = getConfig();
-      config.CREDENTIALS_BASE_URL = '';
+      const config = { ...baseTestConfig, CREDENTIALS_BASE_URL: '' };
 
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config,
       };
       const component = (
         <ProfilePageWrapper
@@ -209,7 +217,7 @@ describe('<ProfilePage />', () => {
     it('successfully redirected to not found page', () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       const navigate = jest.fn();
       useNavigate.mockReturnValue(navigate);
@@ -230,7 +238,7 @@ describe('<ProfilePage />', () => {
     it('calls sendTrackingLogEvent when mounting', () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       render(
         <ProfilePageWrapper
@@ -251,7 +259,7 @@ describe('<ProfilePage />', () => {
     it('navigates to notfound on save error with no username', () => {
       const contextValue = {
         authenticatedUser: { userId: 123, username: 'staff', administrator: true },
-        config: getConfig(),
+        config: baseTestConfig,
       };
       const navigate = jest.fn();
       useNavigate.mockReturnValue(navigate);

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -2967,7 +2967,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                       class="mb-0 small"
                     >
                       Completed on 
-                      3/5/2019
+                      3/4/2019
                     </p>
                   </div>
                   <div
@@ -4179,7 +4179,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                       class="mb-0 small"
                     >
                       Completed on 
-                      3/5/2019
+                      3/4/2019
                     </p>
                   </div>
                   <div

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`<ProfilePage /> Renders correctly in various states app loading 1`] = `
 <div>
@@ -704,7 +704,7 @@ exports[`<ProfilePage /> Renders correctly in various states successfully redire
                   class="pgn-transition-replace-group position-relative pt-0"
                 >
                   <div
-                    style="padding: 0.1px 0px;"
+                    style="padding: .1px 0px;"
                   >
                     <div
                       aria-labelledby="basicInformation-label"
@@ -2530,7 +2530,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                   class="pgn-transition-replace-group position-relative pt-0"
                 >
                   <div
-                    style="padding: 0.1px 0px;"
+                    style="padding: .1px 0px;"
                   >
                     <div
                       aria-labelledby="basicInformation-label"
@@ -2935,7 +2935,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
               >
                 <div
                   class="certificate-type-illustration"
-                  style="background-image: url("icon/mock/path");"
+                  style="background-image: url(icon/mock/path);"
                 />
                 <div
                   class="d-flex flex-column position-relative p-0 width-314px"
@@ -3742,7 +3742,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                   class="pgn-transition-replace-group position-relative pt-0"
                 >
                   <div
-                    style="padding: 0.1px 0px;"
+                    style="padding: .1px 0px;"
                   >
                     <div
                       aria-labelledby="basicInformation-label"
@@ -4147,7 +4147,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
               >
                 <div
                   class="certificate-type-illustration"
-                  style="background-image: url("icon/mock/path");"
+                  style="background-image: url(icon/mock/path);"
                 />
                 <div
                   class="d-flex flex-column position-relative p-0 width-314px"

--- a/src/profile/__snapshots__/ProfilePage.test.jsx.snap
+++ b/src/profile/__snapshots__/ProfilePage.test.jsx.snap
@@ -2967,7 +2967,7 @@ exports[`<ProfilePage /> Renders correctly in various states viewing own profile
                       class="mb-0 small"
                     >
                       Completed on 
-                      3/4/2019
+                      3/5/2019
                     </p>
                   </div>
                   <div
@@ -4179,7 +4179,7 @@ exports[`<ProfilePage /> Renders correctly in various states without credentials
                       class="mb-0 small"
                     >
                       Completed on 
-                      3/4/2019
+                      3/5/2019
                     </p>
                   </div>
                   <div

--- a/src/profile/biodata/BiodataProfileSections.jsx
+++ b/src/profile/biodata/BiodataProfileSections.jsx
@@ -351,12 +351,14 @@ const BiodataProfileSections = () => {
         [pendingSaveStepId]: true,
       }));
       setActiveStepId(pendingSaveStepId);
-      setPendingScrollSectionId(pendingSaveStepId);
+      if (activeStepId !== pendingSaveStepId) {
+        setPendingScrollSectionId(pendingSaveStepId);
+      }
       setPendingSaveStepId(null);
     }
   }, [
     accountUsername, dispatch, drafts, errors, extendedProfile,
-    pendingReturnSectionId, pendingSaveStepId, saveState, interactiveSections, isDeclarationAvailable,
+    pendingReturnSectionId, pendingSaveStepId, saveState, interactiveSections, isDeclarationAvailable, activeStepId,
   ]);
 
   const activeSectionSavedData = getSectionInitialData(activeSection, extendedProfile);
@@ -412,9 +414,11 @@ const BiodataProfileSections = () => {
     }));
   };
 
-  const moveToSection = (sectionId) => {
+  const moveToSection = (sectionId, { shouldScroll = true } = {}) => {
     setActiveStepId(sectionId);
-    setPendingScrollSectionId(sectionId);
+    if (shouldScroll) {
+      setPendingScrollSectionId(sectionId);
+    }
   };
 
   const handleStepClick = (sectionId) => {
@@ -533,7 +537,7 @@ const BiodataProfileSections = () => {
         ...previousStateById,
         [section.id]: true,
       }));
-      moveToSection(section.id);
+      moveToSection(section.id, { shouldScroll: false });
       return;
     }
 

--- a/src/profile/biodata/BiodataSection.jsx
+++ b/src/profile/biodata/BiodataSection.jsx
@@ -18,7 +18,6 @@ import {
   FIELD_NAMES_REQUIRING_VALID_YEAR,
   fieldAllowsOnlyDigits,
   fieldDisallowsDigits,
-  fieldDisallowsSpecialCharacters,
   getRepeatableFieldErrorKey,
   getRepeatableFieldValidationError,
   getSectionError,
@@ -32,9 +31,7 @@ import {
   isProtectedRepeatableColumn,
   isProtectedRepeatableRow,
   normalizeRepeatableRows,
-  removeDigitsFromValue,
   removeNonDigitsFromValue,
-  removeSpecialCharactersFromValue,
   revokeFilePreviewUrl,
   sectionHasValue,
   shouldShowSpouseInformation,
@@ -115,27 +112,6 @@ function normalizeFieldInputValue(field, value) {
     && FIELD_NAMES_REQUIRING_NON_NEGATIVE_NUMBERS.has(field.fieldName)
   ) {
     nextValue = removeNonDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldAllowsOnlyDigits(field.fieldName)
-  ) {
-    nextValue = removeNonDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldDisallowsDigits(field.fieldName)
-  ) {
-    nextValue = removeDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldDisallowsSpecialCharacters(field.fieldName)
-  ) {
-    nextValue = removeSpecialCharactersFromValue(nextValue);
   }
 
   return nextValue;

--- a/src/profile/biodata/RepeatableFieldGroup.jsx
+++ b/src/profile/biodata/RepeatableFieldGroup.jsx
@@ -9,14 +9,11 @@ import {
   FIELD_NAMES_REQUIRING_NON_NEGATIVE_NUMBERS,
   fieldAllowsOnlyDigits,
   fieldDisallowsDigits,
-  fieldDisallowsSpecialCharacters,
   FIELD_NAMES_REQUIRING_VALID_YEAR,
   getRepeatableFieldErrorKey,
   isProtectedRepeatableColumn,
   isProtectedRepeatableRow,
-  removeDigitsFromValue,
   removeNonDigitsFromValue,
-  removeSpecialCharactersFromValue,
   revokeFilePreviewUrl,
 } from './utils';
 
@@ -106,27 +103,6 @@ function normalizeFieldInputValue(field, value) {
     && FIELD_NAMES_REQUIRING_NON_NEGATIVE_NUMBERS.has(field.key)
   ) {
     nextValue = removeNonDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldAllowsOnlyDigits(field.key)
-  ) {
-    nextValue = removeNonDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldDisallowsDigits(field.key)
-  ) {
-    nextValue = removeDigitsFromValue(nextValue);
-  }
-
-  if (
-    (field.type === PROFILE_FIELD_TYPES.TEXT || field.type === PROFILE_FIELD_TYPES.TEXTAREA || !field.type)
-    && fieldDisallowsSpecialCharacters(field.key)
-  ) {
-    nextValue = removeSpecialCharactersFromValue(nextValue);
   }
 
   return nextValue;

--- a/src/profile/biodata/RepeatableFieldGroup.test.jsx
+++ b/src/profile/biodata/RepeatableFieldGroup.test.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import RepeatableFieldGroup from './RepeatableFieldGroup';
 
@@ -32,6 +32,8 @@ const foreignVisitRows = [
 ];
 
 describe('RepeatableFieldGroup', () => {
+  const today = new Date().toISOString().slice(0, 10);
+
   it('does not show a generic column error on every repeatable row', () => {
     render(
       <RepeatableFieldGroup
@@ -82,8 +84,33 @@ describe('RepeatableFieldGroup', () => {
       />,
     );
 
-    expect(screen.getByLabelText('From')).toHaveAttribute('max', '2026-07-01');
+    expect(screen.getByLabelText('From')).toHaveAttribute('max', today);
     expect(screen.getByLabelText('To')).toHaveAttribute('min', '2026-06-28');
-    expect(screen.getByLabelText('To')).toHaveAttribute('max', '2026-07-01');
+    expect(screen.getByLabelText('To')).toHaveAttribute('max', today);
+  });
+
+  it('preserves allowed subject punctuation while editing CSS subject names', () => {
+    const onChange = jest.fn();
+
+    render(
+      <RepeatableFieldGroup
+        repeatable={repeatable}
+        rows={[{ rowId: 'row-1', subject: '' }]}
+        errors={{}}
+        onChange={onChange}
+        onBlur={jest.fn()}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText('Subject'), {
+      target: { value: 'CS & IT' },
+    });
+
+    expect(onChange).toHaveBeenCalledWith('updateCell', {
+      rowIndex: 0,
+      columnKey: 'subject',
+      value: 'CS & IT',
+    });
   });
 });

--- a/src/profile/biodata/apiConfig.js
+++ b/src/profile/biodata/apiConfig.js
@@ -97,7 +97,6 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       education_records: {
         path: 'v1/education/',
-        allowDelete: false,
         submissionSupported: false,
         fieldMap: {
           institute: 'educational_institute',
@@ -206,7 +205,6 @@ export const BIODATA_SECTION_ENDPOINTS = {
     repeatables: {
       occupational_service_group_preferences: {
         path: 'v1/service-group-preferences/',
-        allowDelete: false,
         dedupeBy: 'service_group',
         submissionSupported: false,
         fieldMap: {
@@ -343,7 +341,6 @@ export const BIODATA_SECTION_ENDPOINTS = {
       submissionSupported: true,
       fieldMap: {
         confirmed: 'declaration_confirmed',
-        date: 'declaration_date_demo',
       },
     },
   },

--- a/src/profile/biodata/config.js
+++ b/src/profile/biodata/config.js
@@ -43,6 +43,12 @@ const PROFICIENCY_OPTIONS = [
   { value: 'native', label: 'Native' },
 ];
 
+const SELF_OR_SPONSORED_VISIT_OPTIONS = [
+  { value: '', label: 'Select self or sponsored' },
+  { value: 'self', label: 'Self' },
+  { value: 'sponsored', label: 'Sponsored' },
+];
+
 export const CSS_COMPULSORY_SUBJECT_MARKS = [
   { subject: 'English Essay', total_marks: '100', marks_obtained: '' },
   { subject: 'English Precise and Composition', total_marks: '100', marks_obtained: '' },
@@ -427,8 +433,12 @@ export const BIODATA_SECTIONS = [
         },
         columns: [
           { key: 'country', label: 'Country', placeholder: 'Enter country' },
-          { key: 'purpose_of_visit', label: 'Purpose of visit', placeholder: 'Enter purpose of visit' },
-          { key: 'self_or_sponsored_visit', label: 'Self or sponsored visit', placeholder: 'Enter self or sponsored' },
+          {
+            key: 'purpose_of_visit', label: 'Purpose of visit', type: PROFILE_FIELD_TYPES.TEXT,
+          },
+          {
+            key: 'self_or_sponsored_visit', label: 'Self or sponsored visit', type: PROFILE_FIELD_TYPES.SELECT, options: SELF_OR_SPONSORED_VISIT_OPTIONS,
+          },
           { key: 'from', label: 'From', type: PROFILE_FIELD_TYPES.DATE },
           { key: 'to', label: 'To', type: PROFILE_FIELD_TYPES.DATE },
         ],

--- a/src/profile/biodata/utils.js
+++ b/src/profile/biodata/utils.js
@@ -69,8 +69,24 @@ const FIELD_NAMES_REQUIRING_BASIC_TEXT_CHARACTERS = new Set([
   'subjects_studied',
   'language_name',
   'subject',
-  'first_employment_gap_details_after_education',
   'hobbies',
+  'department_name',
+  'games_played',
+  'father_education',
+  'father_occupation',
+  'mother_education',
+  'mother_occupation',
+  'spouse_education',
+  'spouse_occupation',
+  'examination',
+  'organization_office',
+  'designation_place_of_posting',
+  'agency_holding_examination',
+  'service_group',
+  'country',
+  'education',
+  'occupation',
+  'relationship',
 ]);
 const FIELD_NAMES_REQUIRING_NON_NEGATIVE_NUMBERS = new Set([
   'css_chances_availed',
@@ -121,6 +137,13 @@ const TEXT_FIELDS_EXEMPT_FROM_STRICT_TEXT_RULES = new Set([
   'last_chance_date_year',
   ...PAKISTAN_MOBILE_FIELD_NAMES,
 ]);
+// Exempt fields that are still free-form identifiers (not backed by their own format regex like
+// email/CNIC/phone/year), so they still need to reject symbol-only garbage such as "----".
+const EXEMPT_IDENTIFIER_FIELD_NAMES = new Set([
+  'css_roll_number',
+  'css_merit_position',
+  'merit_position_if_qualified',
+]);
 const FLEXIBLE_TEXT_FIELD_NAMES = new Set([
   'permanent_residential_address',
   'present_residential_address',
@@ -133,6 +156,11 @@ const FLEXIBLE_TEXT_FIELD_NAMES = new Set([
   'scholarships',
   'awards',
   'game_distinctions_awards',
+  'first_employment_gap_details_after_education',
+  'other_income_details',
+  'result_details',
+  'examination_name',
+  'designation',
 ]);
 const CONDITIONAL_FILE_FIELD_DEPENDENCIES = {
   domicile_file: 'district_of_domicile',
@@ -776,6 +804,7 @@ export function fieldDisallowsDigits(fieldName) {
 
 export function fieldDisallowsSpecialCharacters(fieldName) {
   return !TEXT_FIELDS_EXEMPT_FROM_STRICT_TEXT_RULES.has(fieldName)
+    && !FIELD_NAMES_REQUIRING_BASIC_TEXT_CHARACTERS.has(fieldName)
     && !FLEXIBLE_TEXT_FIELD_NAMES.has(fieldName);
 }
 
@@ -829,23 +858,43 @@ function validateTextFieldValue(fieldName, label, value) {
     return '';
   }
 
-  if (fieldDisallowsDigits(fieldName) && (isNumericOnlyValue(trimmedValue) || !containsLetter(trimmedValue))) {
+  // Exempt fields either have their own dedicated format check elsewhere (email, CNIC, phone,
+  // year) or are free-form identifiers (roll number, merit position) that still shouldn't accept
+  // symbol-only garbage like "----".
+  if (TEXT_FIELDS_EXEMPT_FROM_STRICT_TEXT_RULES.has(fieldName)) {
+    if (
+      EXEMPT_IDENTIFIER_FIELD_NAMES.has(fieldName)
+      && !containsLetter(trimmedValue)
+      && !containsDigit(trimmedValue)
+    ) {
+      return `${label} cannot be only symbols.`;
+    }
+    return '';
+  }
+
+  if (FLEXIBLE_TEXT_FIELD_NAMES.has(fieldName)) {
+    return containsLetter(trimmedValue) ? '' : `${label} must contain at least one letter.`;
+  }
+
+  // Every remaining tier (strict default, and basic) disallows digits entirely.
+  if (isNumericOnlyValue(trimmedValue)) {
     return `${label} cannot be numbers only.`;
   }
 
-  if (fieldDisallowsDigits(fieldName) && containsDigit(trimmedValue)) {
+  if (containsDigit(trimmedValue)) {
     return `${label} cannot contain numbers.`;
   }
 
-  if (fieldDisallowsSpecialCharacters(fieldName) && !LETTERS_AND_SPACES_FORMAT.test(trimmedValue)) {
-    return `${label} can only contain letters and spaces.`;
-  }
+  const isBasicTextField = FIELD_NAMES_REQUIRING_BASIC_TEXT_CHARACTERS.has(fieldName);
+  const allowedFormat = isBasicTextField ? TEXT_WITH_BASIC_PUNCTUATION_FORMAT : LETTERS_AND_SPACES_FORMAT;
 
-  if (
-    FIELD_NAMES_REQUIRING_BASIC_TEXT_CHARACTERS.has(fieldName)
-    && !TEXT_WITH_BASIC_PUNCTUATION_FORMAT.test(trimmedValue)
-  ) {
-    return `Enter a valid ${label.toLowerCase()}.`;
+  if (!allowedFormat.test(trimmedValue)) {
+    return isBasicTextField
+      ? `${label} can only contain letters, numbers, and spaces.`
+      : `${label} can only contain letters and spaces.`;
+  }
+  if (isBasicTextField && !containsLetter(trimmedValue)) {
+    return `${label} must contain at least one letter.`;
   }
 
   return '';
@@ -1490,6 +1539,11 @@ export function sectionIsComplete(section, sectionData) {
     locallyComplete = employmentHasRequiredValues(section, sectionData);
   }
 
+  if (locallyComplete) {
+    const sanitizedData = getSanitizedSectionData(section, sectionData);
+    locallyComplete = Object.keys(validateSectionDraft(section, sanitizedData)).length === 0;
+  }
+
   const submittedFieldName = getSectionSubmittedFieldName(section.id);
 
   if (Object.prototype.hasOwnProperty.call(sectionData || {}, submittedFieldName)) {
@@ -1595,7 +1649,10 @@ export function getSectionErrorFields(section, errors = {}, sectionData = null) 
     ...(visibleRepeatables.flatMap((repeatable) => [
       {
         fieldName: repeatable.storageFieldName,
-        label: repeatable.itemLabel,
+        label: (
+          section.id === CSS_EXAM_DETAILS_SECTION_ID
+          && repeatable.storageFieldName === CSS_SUBJECT_MARKS_FIELD_NAME
+        ) ? 'Elective subjects' : repeatable.itemLabel,
       },
       ...repeatable.columns.map(({ key, label }) => ({
         fieldName: key,
@@ -1613,6 +1670,14 @@ export function getSectionErrorFields(section, errors = {}, sectionData = null) 
 }
 
 export function getSectionErrorSummary(section, errors = {}, sectionData = null) {
+  const repeatableGroupError = (section.repeatables || []).find(
+    (repeatable) => errors[repeatable.storageFieldName]?.userMessage,
+  );
+
+  if (repeatableGroupError) {
+    return errors[repeatableGroupError.storageFieldName].userMessage;
+  }
+
   const errorFields = getSectionErrorFields(section, errors, sectionData);
 
   if (errorFields.length === 0 && getSectionError(section, errors)) {

--- a/src/profile/biodata/utils.test.js
+++ b/src/profile/biodata/utils.test.js
@@ -1,5 +1,10 @@
 import { BIODATA_SECTION_MAP } from './config';
-import { sectionIsComplete, validateSectionDraft } from './utils';
+import {
+  getSectionErrorFields,
+  getSectionErrorSummary,
+  sectionIsComplete,
+  validateSectionDraft,
+} from './utils';
 
 describe('biodata utils', () => {
   describe('validateSectionDraft', () => {
@@ -77,6 +82,83 @@ describe('biodata utils', () => {
       expect(result['education_records.row-1.subjects_studied']).toEqual({
         userMessage: 'Subjects Studied cannot be numbers only.',
       });
+    });
+
+    it('rejects a symbol-only educational institute instead of silently accepting it', () => {
+      const result = validateSectionDraft(BIODATA_SECTION_MAP.education, {
+        education_records: [{
+          rowId: 'row-1',
+          educational_institute: '----',
+          attended_from: '2015-01-01',
+          attended_to: '2018-01-01',
+          examination: 'Bachelors',
+          year_of_passing: '2018',
+          grade_division: 'First Division',
+          subjects_studied: 'Computer Science',
+          education_degree_attachment: 'degree.pdf',
+        }],
+      });
+
+      expect(result['education_records.row-1.educational_institute']).toEqual({
+        userMessage: 'Educational Institute must contain at least one letter.',
+      });
+    });
+
+    it('rejects a symbol-only CSS roll number', () => {
+      const result = validateSectionDraft(BIODATA_SECTION_MAP.cssExamDetails, {
+        css_roll_number: '----',
+        css_merit_position: '1',
+        css_chances_availed: '1',
+        applied_for_forthcoming_css_exam: 'Yes',
+        intend_to_sit_for_forthcoming_css_exam: 'No',
+        last_chance_date_year: '2026',
+      });
+
+      expect(result.css_roll_number).toEqual({
+        userMessage: 'CSS Roll Number cannot be only symbols.',
+      });
+    });
+
+    it('rejects a symbol-only present residential address', () => {
+      const result = validateSectionDraft(BIODATA_SECTION_MAP.contactInformation, {
+        permanent_residential_address: 'Main Street',
+        permanent_phone_number: '03001234567',
+        present_residential_address: '-=--',
+        present_phone_number: '03001234567',
+        contact_address_lahore: 'Lahore',
+        lahore_phone_number: '03001234567',
+        mobile_number: '03001234567',
+        contact_email: 'valid@example.com',
+      });
+
+      expect(result.present_residential_address).toEqual({
+        userMessage: 'Present residential address must contain at least one letter.',
+      });
+    });
+
+    it('allows digits in employment gap details now that it needs real dates', () => {
+      const result = validateSectionDraft(BIODATA_SECTION_MAP.employment, {
+        is_first_job: 'Yes',
+        first_employment_gap_details_after_education: 'Prepared for CSS exam from 2019 to 2021',
+      });
+
+      expect(result.first_employment_gap_details_after_education).toBeUndefined();
+    });
+
+    it('does not apply free-text format rules to the purpose-of-visit select field', () => {
+      const result = validateSectionDraft(BIODATA_SECTION_MAP.foreignVisits, {
+        foreign_visits_not_applicable: false,
+        foreign_visits: [{
+          rowId: 'visit-1',
+          country: 'Turkey',
+          purpose_of_visit: 'training',
+          self_or_sponsored_visit: 'Self',
+          from: '2022-05-01',
+          to: '2022-05-10',
+        }],
+      });
+
+      expect(result['foreign_visits.visit-1.purpose_of_visit']).toBeUndefined();
     });
 
     it('rejects future education dates and future year of passing', () => {
@@ -411,6 +493,51 @@ describe('biodata utils', () => {
         competitive_examinations_not_applicable: true,
         competitiveExaminations_is_submitted: true,
       })).toBe(true);
+    });
+
+    it('does not treat a foreign visit row as complete when a required select is empty', () => {
+      expect(sectionIsComplete(BIODATA_SECTION_MAP.foreignVisits, {
+        foreign_visits_not_applicable: false,
+        foreign_visits: [{
+          rowId: 'visit-1',
+          country: 'U.A.E',
+          purpose_of_visit: 'self',
+          self_or_sponsored_visit: '',
+          from: '2023-02-08',
+          to: '2023-02-10',
+        }],
+      })).toBe(false);
+    });
+
+    it('treats a foreign visit row as complete once every required field is filled', () => {
+      expect(sectionIsComplete(BIODATA_SECTION_MAP.foreignVisits, {
+        foreign_visits_not_applicable: false,
+        foreign_visits: [{
+          rowId: 'visit-1',
+          country: 'U.A.E',
+          purpose_of_visit: 'self',
+          self_or_sponsored_visit: 'self',
+          from: '2023-02-08',
+          to: '2023-02-10',
+        }],
+      })).toBe(true);
+    });
+  });
+
+  describe('getSectionErrorSummary', () => {
+    it('shows the exact elective-subject-count message at the top instead of a generic field name', () => {
+      const errors = {
+        css_subject_marks: {
+          userMessage: 'Add exactly 6 elective subjects.',
+        },
+      };
+
+      expect(getSectionErrorSummary(BIODATA_SECTION_MAP.cssExamDetails, errors, {}))
+        .toBe('Add exactly 6 elective subjects.');
+      expect(getSectionErrorFields(BIODATA_SECTION_MAP.cssExamDetails, errors, {})).toContainEqual({
+        fieldName: 'css_subject_marks',
+        label: 'Elective subjects',
+      });
     });
   });
 });

--- a/src/profile/data/pact-profile.test.js
+++ b/src/profile/data/pact-profile.test.js
@@ -30,10 +30,18 @@ const provider = new PactV3({
   provider: 'edx-platform',
 });
 
+let baseConfig = {};
+
 describe('getAccount for one username', () => {
   beforeAll(async () => {
     initializeMockApp();
+    baseConfig = JSON.parse(JSON.stringify(getConfig()));
   });
+
+  afterEach(() => {
+    setConfig(baseConfig);
+  });
+
   it('returns a HTTP 200 and user information', async () => {
     const username200 = 'staff';
     await provider.addInteraction({

--- a/src/profile/data/sagas.js
+++ b/src/profile/data/sagas.js
@@ -170,9 +170,16 @@ export function* handleSaveProfile(action) {
     if (biodataSection) {
       const sectionDraft = drafts[action.payload.formId]
         || buildSectionDraftFromExtendedProfile(action.payload.formId, account.extendedProfile || []);
+      // Diff against what the server actually has right now, not the redux-cached
+      // extendedProfile snapshot — a row created earlier in this same session may not be
+      // reflected there yet, which previously caused its delete to be silently skipped.
+      const liveExtendedProfile = yield call(
+        ProfileApiService.getBiodataSectionProfile,
+        action.payload.formId,
+      );
       const committedSectionData = buildSectionDraftFromExtendedProfile(
         action.payload.formId,
-        account.extendedProfile || [],
+        liveExtendedProfile,
       );
 
       accountDrafts = yield call(
@@ -236,9 +243,13 @@ export function* handleSaveDraftSection(action) {
       return;
     }
 
+    const liveExtendedProfile = yield call(
+      ProfileApiService.getBiodataSectionProfile,
+      action.payload.formId,
+    );
     const committedSectionData = buildSectionDraftFromExtendedProfile(
       action.payload.formId,
-      account.extendedProfile || [],
+      liveExtendedProfile,
     );
 
     const result = yield call(

--- a/src/profile/data/sagas.test.js
+++ b/src/profile/data/sagas.test.js
@@ -19,6 +19,7 @@ jest.mock('./services', () => ({
   getPreferences: jest.fn(),
   getAccount: jest.fn(),
   getBiodataProfile: jest.fn(),
+  getBiodataSectionProfile: jest.fn(),
   saveBiodataSection: jest.fn(),
   validateBiodataSection: jest.fn(),
   getCourseCertificates: jest.fn(),
@@ -232,6 +233,10 @@ describe('RootSaga', () => {
       expect(gen.next().value).toEqual(select(handleSaveProfileSelector));
       expect(gen.next(selectorPayload).value).toEqual(put(profileActions.saveProfileBegin()));
       expect(gen.next().value).toEqual(call(
+        ProfileApiService.getBiodataSectionProfile,
+        'basicInformation',
+      ));
+      expect(gen.next([]).value).toEqual(call(
         ProfileApiService.saveBiodataSection,
         'basicInformation',
         selectorPayload.drafts.basicInformation,

--- a/src/profile/data/services.js
+++ b/src/profile/data/services.js
@@ -178,6 +178,21 @@ function getLatestRepeatableRow(candidateRow = null, existingRow = null) {
   return Number(candidateRow?.id || 0) > Number(existingRow?.id || 0) ? candidateRow : existingRow;
 }
 
+function buildRepeatableRowMatchKey(values = {}) {
+  return JSON.stringify(
+    Object.keys(values || {})
+      .sort()
+      .reduce((accumulator, key) => {
+        accumulator[key] = values[key] ?? '';
+        return accumulator;
+      }, {}),
+  );
+}
+
+function extractRepeatableServerRows(data) {
+  return Array.isArray(data) ? data : data?.results || [];
+}
+
 function dedupeRepeatableRows(endpoint, rows = []) {
   if (!endpoint.dedupeBy) {
     return rows;
@@ -261,7 +276,7 @@ async function getRepeatableBiodataSection(section, repeatable, endpoint, flatRe
   }
 }
 
-async function getBiodataSectionProfile(sectionId) {
+export async function getBiodataSectionProfile(sectionId) {
   const section = getSectionById(sectionId);
 
   if (!section) {
@@ -298,16 +313,48 @@ async function updateRepeatableRows(endpoint, committedRows, draftRows) {
   const endpointPath = endpoint.path;
   const shouldPostRows = endpoint.rowMethod === 'post';
   const shouldDeleteMissingRows = endpoint.allowDelete !== false && !shouldPostRows;
+  const matchedCommittedRowIndexes = new Set();
+  const committedRowsByMatchKey = committedRows.reduce((accumulator, row, index) => {
+    if (row?.backendId == null) {
+      return accumulator;
+    }
+
+    const matchKey = buildRepeatableRowMatchKey(row.values);
+    if (!accumulator[matchKey]) {
+      accumulator[matchKey] = [];
+    }
+    accumulator[matchKey].push(index);
+    return accumulator;
+  }, {});
   const normalizedDraftRows = draftRows.map((row, index) => {
     if (row.backendId != null) {
       return row;
     }
 
+    const matchKey = buildRepeatableRowMatchKey(row.values);
+    const matchingCommittedRowIndexes = committedRowsByMatchKey[matchKey] || [];
+    const matchedCommittedRowIndex = matchingCommittedRowIndexes.find(
+      committedRowIndex => !matchedCommittedRowIndexes.has(committedRowIndex),
+    );
+
+    if (matchedCommittedRowIndex != null) {
+      matchedCommittedRowIndexes.add(matchedCommittedRowIndex);
+      return {
+        ...row,
+        backendId: committedRows[matchedCommittedRowIndex].backendId,
+      };
+    }
+
     const committedRow = committedRows[index];
-    if (!committedRow || committedRow.backendId == null) {
+    if (
+      !committedRow
+      || committedRow.backendId == null
+      || matchedCommittedRowIndexes.has(index)
+    ) {
       return row;
     }
 
+    matchedCommittedRowIndexes.add(index);
     return {
       ...row,
       backendId: committedRow.backendId,
@@ -346,32 +393,63 @@ async function updateRepeatableRows(endpoint, committedRows, draftRows) {
     return accumulator;
   }, {});
 
-  const operations = [];
+  const rowOperations = [];
 
   normalizedDraftRows.forEach((row) => {
     const payload = buildBiodataRequestPayload(row.values);
     if (row.backendId != null && !shouldPostRows) {
       const url = getBiodataEndpointUrl(`${endpointPath}${row.backendId}/`, { includeTargetUser: true });
-      operations.push(payload.headers
+      rowOperations.push(payload.headers
         ? getHttpClient().patch(url, payload.data, { headers: payload.headers })
         : getHttpClient().patch(url, payload.data));
     } else {
       const url = getBiodataEndpointUrl(endpointPath, { includeTargetUser: true });
-      operations.push(payload.headers
+      rowOperations.push(payload.headers
         ? getHttpClient().post(url, payload.data, { headers: payload.headers })
         : getHttpClient().post(url, payload.data));
     }
   });
 
+  const deleteOperations = [];
   if (shouldDeleteMissingRows) {
     Object.keys(committedRowMap).forEach((backendId) => {
       if (!draftRowMap[backendId]) {
-        operations.push(getHttpClient().delete(getBiodataEndpointUrl(`${endpointPath}${backendId}/`, { includeTargetUser: true })));
+        deleteOperations.push(getHttpClient().delete(getBiodataEndpointUrl(`${endpointPath}${backendId}/`, { includeTargetUser: true })));
       }
     });
   }
 
-  await Promise.all(operations);
+  const rowResponses = await Promise.all(rowOperations);
+  await Promise.all(deleteOperations);
+
+  if (shouldDeleteMissingRows) {
+    const { data } = await getHttpClient().get(
+      getBiodataEndpointUrl(endpointPath, { includeTargetUser: true }),
+    );
+    const serverRows = extractRepeatableServerRows(data);
+    const matchedServerIds = new Set(
+      rowResponses
+        .map(response => response?.data?.id)
+        .filter(id => id != null)
+        .map(id => String(id)),
+    );
+
+    normalizedDraftRows.forEach((row) => {
+      if (row.backendId != null) {
+        matchedServerIds.add(String(row.backendId));
+      }
+    });
+
+    const cleanupDeletes = serverRows
+      .filter(serverRow => serverRow?.id != null && !matchedServerIds.has(String(serverRow.id)))
+      .map(serverRow => getHttpClient().delete(
+        getBiodataEndpointUrl(`${endpointPath}${serverRow.id}/`, { includeTargetUser: true }),
+      ));
+
+    if (cleanupDeletes.length > 0) {
+      await Promise.all(cleanupDeletes);
+    }
+  }
 }
 
 export async function getAccount(username) {

--- a/src/profile/data/services.test.js
+++ b/src/profile/data/services.test.js
@@ -525,11 +525,91 @@ describe('services', () => {
       );
     });
 
-    it('should not issue delete requests for missing committed education rows', async () => {
+    it('should delete removed education rows', async () => {
       mockHttpClient.patch.mockResolvedValue({});
       mockHttpClient.post.mockResolvedValue({});
       mockHttpClient.delete.mockResolvedValue({});
-      mockHttpClient.get.mockResolvedValue({ data: { results: [] } });
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [{
+            id: 3,
+            institute: 'University of Sargodha',
+            attended_from: '2015-09-23',
+            attended_to: '2019-09-12',
+            examination: 'xyz',
+            year_of_passing: '2019',
+            grade: 'First',
+            subjects: 'Computer Science',
+          }],
+        })
+        .mockResolvedValueOnce({ data: {} });
+
+      await saveBiodataSection(
+        'education',
+        {
+          education_records: [{
+            rowId: 'row-1',
+            backendId: 3,
+            educational_institute: 'University of Sargodha',
+            attended_from: '2015-09-23',
+            attended_to: '2019-09-12',
+            examination: 'xyz',
+            year_of_passing: '2019',
+            grade_division: 'First',
+            subjects_studied: 'Computer Science',
+          }],
+        },
+        {
+          education_records: [
+            {
+              rowId: 'row-1',
+              backendId: 3,
+              educational_institute: 'University of Sargodha',
+              attended_from: '2015-09-23',
+              attended_to: '2019-09-12',
+              examination: 'xyz',
+              year_of_passing: '2019',
+              grade_division: 'First',
+              subjects_studied: 'Computer Science',
+            },
+            {
+              rowId: 'row-2',
+              backendId: 4,
+              educational_institute: 'Old Record',
+              attended_from: '2011-01-01',
+              attended_to: '2013-01-01',
+              examination: 'Old',
+              year_of_passing: '2013',
+              grade_division: 'Second',
+              subjects_studied: 'History',
+            },
+          ],
+        },
+      );
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        expect.stringMatching(/\/education\/4\/$/),
+      );
+    });
+
+    it('should delete missing committed education rows', async () => {
+      mockHttpClient.patch.mockResolvedValue({});
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.delete.mockResolvedValue({});
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [{
+            id: 3,
+            institute: 'University of Sargodha',
+            attended_from: '2015-09-23',
+            attended_to: '2019-09-12',
+            examination: 'xyz',
+            year_of_passing: '2019',
+            grade: 'First',
+            subjects: 'Computer Science',
+          }],
+        })
+        .mockResolvedValueOnce({ data: {} });
 
       await saveBiodataSection(
         'education',
@@ -583,7 +663,279 @@ describe('services', () => {
           headers: { 'Content-Type': 'application/json' },
         }),
       );
-      expect(mockHttpClient.delete).not.toHaveBeenCalled();
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        expect.stringMatching(/\/education\/4\/$/),
+      );
+    });
+
+    it('should keep a newly added education row after save and cleanup refresh', async () => {
+      mockHttpClient.patch.mockResolvedValue({ data: { id: 3 } });
+      mockHttpClient.post.mockResolvedValue({
+        data: {
+          id: 8,
+          institute: 'NDU',
+          attended_from: '2020-01-01',
+          attended_to: '2022-01-01',
+          examination: 'Masters',
+          year_of_passing: '2022',
+          grade: 'A',
+          subjects: 'Policy',
+          degree_file: '/media/ndu.pdf',
+        },
+      });
+      mockHttpClient.delete.mockResolvedValue({});
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 3,
+              institute: 'University of Sargodha',
+              attended_from: '2015-09-23',
+              attended_to: '2019-09-12',
+              examination: 'xyz',
+              year_of_passing: '2019',
+              grade: 'First',
+              subjects: 'Computer Science',
+              degree_file: '/media/uos.pdf',
+            },
+            {
+              id: 8,
+              institute: 'NDU',
+              attended_from: '2020-01-01',
+              attended_to: '2022-01-01',
+              examination: 'Masters',
+              year_of_passing: '2022',
+              grade: 'A',
+              subjects: 'Policy',
+              degree_file: '/media/ndu.pdf',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ data: {} });
+
+      await saveBiodataSection(
+        'education',
+        {
+          education_records: [
+            {
+              rowId: 'row-1',
+              backendId: 3,
+              educational_institute: 'University of Sargodha',
+              attended_from: '2015-09-23',
+              attended_to: '2019-09-12',
+              examination: 'xyz',
+              year_of_passing: '2019',
+              grade_division: 'First',
+              subjects_studied: 'Computer Science',
+            },
+            {
+              rowId: 'row-2',
+              educational_institute: 'NDU',
+              attended_from: '2020-01-01',
+              attended_to: '2022-01-01',
+              examination: 'Masters',
+              year_of_passing: '2022',
+              grade_division: 'A',
+              subjects_studied: 'Policy',
+            },
+          ],
+        },
+        {
+          education_records: [
+            {
+              rowId: 'row-1',
+              backendId: 3,
+              educational_institute: 'University of Sargodha',
+              attended_from: '2015-09-23',
+              attended_to: '2019-09-12',
+              examination: 'xyz',
+              year_of_passing: '2019',
+              grade_division: 'First',
+              subjects_studied: 'Computer Science',
+            },
+          ],
+        },
+      );
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        expect.stringMatching(/\/education\/$/),
+        expect.objectContaining({
+          institute: 'NDU',
+          attended_from: '2020-01-01',
+          attended_to: '2022-01-01',
+          examination: 'Masters',
+          year_of_passing: '2022',
+          grade: 'A',
+          subjects: 'Policy',
+        }),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(mockHttpClient.delete).not.toHaveBeenCalledWith(
+        expect.stringMatching(/\/education\/8\/$/),
+      );
+    });
+
+    it('should match language rows by content before index when a deleted earlier row shifts positions', async () => {
+      mockHttpClient.patch.mockResolvedValue({});
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.delete.mockResolvedValue({});
+      mockHttpClient.get.mockImplementation((url) => {
+        if (url.endsWith('/languages/')) {
+          return Promise.resolve({
+            data: [{
+              id: 7,
+              language: 'Urdu',
+              speaking: 'basic',
+              reading: 'intermediate',
+              writing: 'intermediate',
+              is_submitted: true,
+            }],
+          });
+        }
+
+        if (url.endsWith('/declaration/')) {
+          return Promise.resolve({ data: {} });
+        }
+
+        return Promise.resolve({ data: {} });
+      });
+
+      await saveBiodataSection(
+        'languages',
+        {
+          language_proficiencies: [{
+            rowId: 'row-1',
+            language_name: 'Urdu',
+            speaking_proficiency: 'basic',
+            reading_proficiency: 'intermediate',
+            writing_proficiency: 'intermediate',
+          }],
+        },
+        {
+          language_proficiencies: [
+            {
+              rowId: 'row-english',
+              backendId: 6,
+              language_name: 'English',
+              speaking_proficiency: 'basic',
+              reading_proficiency: 'intermediate',
+              writing_proficiency: 'advanced',
+            },
+            {
+              rowId: 'row-urdu',
+              backendId: 7,
+              language_name: 'Urdu',
+              speaking_proficiency: 'basic',
+              reading_proficiency: 'intermediate',
+              writing_proficiency: 'intermediate',
+            },
+          ],
+        },
+      );
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/7\/$/),
+        expect.objectContaining({
+          language: 'Urdu',
+          speaking: 'basic',
+          reading: 'intermediate',
+          writing: 'intermediate',
+        }),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/6\/$/),
+      );
+      expect(mockHttpClient.patch).not.toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/6\/$/),
+        expect.anything(),
+        expect.anything(),
+      );
+      expect(mockHttpClient.delete).not.toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/7\/$/),
+      );
+    });
+
+    it('should delete extra language rows still returned by a follow-up GET after patching', async () => {
+      mockHttpClient.patch.mockResolvedValue({});
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.delete.mockResolvedValue({});
+      mockHttpClient.get
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 6,
+              language: 'English',
+              speaking: 'basic',
+              reading: 'intermediate',
+              writing: 'advanced',
+              is_submitted: true,
+            },
+            {
+              id: 7,
+              language: 'Urdu',
+              speaking: 'basic',
+              reading: 'intermediate',
+              writing: 'intermediate',
+              is_submitted: true,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          data: [{
+            id: 6,
+            language: 'English',
+            speaking: 'basic',
+            reading: 'intermediate',
+            writing: 'advanced',
+            is_submitted: true,
+          }],
+        })
+        .mockResolvedValueOnce({ data: {} });
+
+      await saveBiodataSection(
+        'languages',
+        {
+          language_proficiencies: [{
+            rowId: 'row-1',
+            backendId: 6,
+            language_name: 'English',
+            speaking_proficiency: 'basic',
+            reading_proficiency: 'intermediate',
+            writing_proficiency: 'advanced',
+          }],
+        },
+        {
+          language_proficiencies: [{
+            rowId: 'row-1',
+            backendId: 6,
+            language_name: 'English',
+            speaking_proficiency: 'basic',
+            reading_proficiency: 'intermediate',
+            writing_proficiency: 'advanced',
+          }],
+        },
+      );
+
+      expect(mockHttpClient.patch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/6\/$/),
+        expect.objectContaining({
+          language: 'English',
+          speaking: 'basic',
+          reading: 'intermediate',
+          writing: 'advanced',
+        }),
+        expect.objectContaining({
+          headers: { 'Content-Type': 'application/json' },
+        }),
+      );
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        expect.stringMatching(/\/languages\/7\/$/),
+      );
     });
 
     it('should patch existing CSS service group preferences instead of reposting them', async () => {
@@ -662,6 +1014,60 @@ describe('services', () => {
         expect.anything(),
       );
       expect(mockHttpClient.delete).not.toHaveBeenCalled();
+    });
+
+    it('should delete removed CSS service group preferences', async () => {
+      mockHttpClient.patch.mockResolvedValue({});
+      mockHttpClient.post.mockResolvedValue({});
+      mockHttpClient.delete.mockResolvedValue({});
+      mockHttpClient.get
+        .mockResolvedValueOnce({ data: {} })
+        .mockResolvedValueOnce({
+          data: [
+            {
+              id: 4,
+              service_group: 'PAS',
+              priority: '1',
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ data: {} });
+
+      await saveBiodataSection(
+        'cssExamDetails',
+        {
+          occupational_service_group_preferences: [
+            {
+              rowId: 'pref-1',
+              backendId: 4,
+              service_group: 'PAS',
+              priority: '1',
+            },
+          ],
+          css_subject_marks: [],
+        },
+        {
+          occupational_service_group_preferences: [
+            {
+              rowId: 'pref-1',
+              backendId: 4,
+              service_group: 'PAS',
+              priority: '1',
+            },
+            {
+              rowId: 'pref-2',
+              backendId: 5,
+              service_group: 'IRS',
+              priority: '2',
+            },
+          ],
+          css_subject_marks: [],
+        },
+      );
+
+      expect(mockHttpClient.delete).toHaveBeenCalledWith(
+        expect.stringMatching(/\/service-group-preferences\/5\/$/),
+      );
     });
 
     it('should map repeatable backend validation errors to UI field names', async () => {

--- a/src/profile/fbr-profile/FbrProfileTabs.jsx
+++ b/src/profile/fbr-profile/FbrProfileTabs.jsx
@@ -1,4 +1,6 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, {
+  useEffect, useMemo, useRef, useState,
+} from 'react';
 import PropTypes from 'prop-types';
 import { getAuthenticatedHttpClient } from '@edx/frontend-platform/auth';
 import {
@@ -703,7 +705,9 @@ const EditRequestPanel = () => {
   );
 };
 
-const FbrProfileTabs = ({ profile, showStpBiodataForm, onProfileUpdated }) => {
+const FbrProfileTabs = ({
+  profile, showStpBiodataForm, requiresStpBiodataCompletion, onProfileUpdated,
+}) => {
   const [batches, setBatches] = useState([]);
 
   useEffect(() => {
@@ -741,6 +745,18 @@ const FbrProfileTabs = ({ profile, showStpBiodataForm, onProfileUpdated }) => {
 
   const [activeTab, setActiveTab] = useState(tabs[0]?.id || 'profile');
   const safeActiveTab = tabs.some(tab => tab.id === activeTab) ? activeTab : tabs[0]?.id;
+
+  const hasAutoSelectedStpTabRef = useRef(false);
+  useEffect(() => {
+    if (
+      showStpBiodataForm
+      && requiresStpBiodataCompletion
+      && !hasAutoSelectedStpTabRef.current
+    ) {
+      hasAutoSelectedStpTabRef.current = true;
+      setActiveTab('stp-biodata');
+    }
+  }, [showStpBiodataForm, requiresStpBiodataCompletion]);
 
   if (!profile) {
     return null;
@@ -785,12 +801,14 @@ const FbrProfileTabs = ({ profile, showStpBiodataForm, onProfileUpdated }) => {
 FbrProfileTabs.propTypes = {
   profile: profileShape,
   showStpBiodataForm: PropTypes.bool,
+  requiresStpBiodataCompletion: PropTypes.bool,
   onProfileUpdated: PropTypes.func,
 };
 
 FbrProfileTabs.defaultProps = {
   profile: null,
   showStpBiodataForm: false,
+  requiresStpBiodataCompletion: false,
   onProfileUpdated: () => {},
 };
 


### PR DESCRIPTION
This PR fixes repeatable biodata save behavior in the profile MFE, especially for sections where users can add or remove rows such as languages and education. It preserves row identity across saves, refreshes section state from the backend before diffing, and cleans up stale rows so removed entries stay deleted and newly added entries remain visible when navigating between steps.